### PR TITLE
Handling the case where 'long' is 0.

### DIFF
--- a/src/finaletoolkit/frag/delfi.py
+++ b/src/finaletoolkit/frag/delfi.py
@@ -241,7 +241,7 @@ def delfi(input_file: str,
     if (verbose):
         stderr.write('Calculating ratio...\n')
 
-    trimmed_windows['ratio'] = trimmed_windows['short']/trimmed_windows['long']
+    trimmed_windows['ratio'] = np.where(trimmed_windows['long'] == 0, np.nan, trimmed_windows['short'] / trimmed_windows['long']) #handle the case where the 'long' is 0.
 
     # remove nocov windows
     if remove_nocov:


### PR DESCRIPTION
In some sparse fragment files, we will see that the short and long ratio are both zero. In the current implementation, the ratio is empty in the output file. Here, we add a np.NaN, such that the ratio is now NaN rather than empty.