### PR TITLE
Fix namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.7] - 2024-11-27
+
+### Fixed
+- subpackages can now be accessed when importing `finaletoolkit`. Previously,
+the following code resulted in an error:
+```python
+>>> import finaletoolkit as ftk
+>>> help(ftk.frag)
+---------------------------------------------------------------------------
+AttributeError                            Traceback (most recent call last)
+Cell In[3], line 1
+----> 1 ftk.frag
+
+AttributeError: module 'finaletoolkit' has no attribute 'frag'
+```
+Now this is a valid way to access subpackages `cli`, `frag`, `genome`, and
+`utils`.
+
 ## [0.7.6] - 2024-11-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,8 @@ the following code resulted in an error:
 ```python
 >>> import finaletoolkit as ftk
 >>> help(ftk.frag)
----------------------------------------------------------------------------
-AttributeError                            Traceback (most recent call last)
-Cell In[3], line 1
-----> 1 ftk.frag
-
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
 AttributeError: module 'finaletoolkit' has no attribute 'frag'
 ```
 Now this is a valid way to access subpackages `cli`, `frag`, `genome`, and

--- a/src/finaletoolkit/__init__.py
+++ b/src/finaletoolkit/__init__.py
@@ -4,3 +4,4 @@ cell-free DNA from paired-end sequencing data.
 """
 
 from finaletoolkit.version import __version__
+from . import cli, frag, genome, utils

--- a/src/finaletoolkit/version.py
+++ b/src/finaletoolkit/version.py
@@ -2,5 +2,5 @@
 Single-source module for the package version number.
 """
 
-__version__ = "0.7.6"
+__version__ = "0.7.7"
 


### PR DESCRIPTION
Previously, the following code would result in an error:
```python
>>> import finaletoolkit as ftk
>>> help(ftk.frag)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'finaletoolkit' has no attribute 'frag'
```
Now this is a valid way to access subpackages `cli`, `frag`, `genome`, and
`utils`.