### PR TITLE
Fix cleavage profile chrom sizes, add S150 and breakpoint-motifs

### DIFF
--- a/docs/documentation/api_reference/breakpointmotifs.rst
+++ b/docs/documentation/api_reference/breakpointmotifs.rst
@@ -1,0 +1,16 @@
+Breakpoint Motifs
+======================================
+
+.. autoclass:: finaletoolkit.frag.BreakpointMotifFreqs
+   :members:
+
+.. autoclass:: finaletoolkit.frag.BreakpointMotifsIntervals
+   :members:
+
+.. autofunction:: finaletoolkit.frag.region_breakpoint_motifs
+
+.. autofunction:: finaletoolkit.frag.breakpoint_motifs
+
+.. autofunction:: finaletoolkit.frag.interval_breakpoint_motifs
+
+

--- a/docs/documentation/api_reference/index.rst
+++ b/docs/documentation/api_reference/index.rst
@@ -9,6 +9,7 @@ API
    wps
    delfi
    endmotifs
+   breakpointmotifs
    cleavageprofile
    fragfile
    genomeutils

--- a/docs/documentation/user_guide/features.rst
+++ b/docs/documentation/user_guide/features.rst
@@ -9,7 +9,7 @@ Features
 Fragment Length
 -----------------------
 
-**FinaleToolkit** can calculate the fragment length distribution and summary statistics of cell-free DNA fragments.
+**FinaleToolkit** can calculate the fragment length distribution and summary statistics of cell-free DNA fragments over intervals.
 
 -----------------------
 Fragment Coverage
@@ -34,10 +34,16 @@ DELFI
 DELFI is a metric that was introduced to identify abnormalities in cfDNA from their fragmentation patterns. In the original paper, DELFI was used to categorize patients with cancer and the associated tumor tissues of origin. The associated DELFI score is the ratio between the GC%-corrected short fragment count and the GC%-corrected long fragment count.
 
 -----------------------
-End Motifs
+End-Motifs
 -----------------------
 
 **FinaleToolkit** can calculate the frequency of end-motif k-mers of cell-free DNA fragments. Since end motifs are specific sequences found at the ends of cfDNA fragments resulting from cleavage, they can be used to potentially detect patterns associated with certain conditions or diseases.
+
+-----------------------
+Breakpoint Motifs
+-----------------------
+
+**FinaleToolkit** can calculate the frequency of breakpoint-motif k-mers of cell-free DNA fragments. Like end-motifs, they can be used to potentially detect patterns associated with certain conditions or diseases.
 
 -----------------------------
 Motif Diversity Score (MDS)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics",
 ]
 dependencies = [
-    "numpy",
+    "numpy>=2",
     "pysam",
     "pybigwig",
     "py2bit",

--- a/src/finaletoolkit/cli/main_cli.py
+++ b/src/finaletoolkit/cli/main_cli.py
@@ -267,8 +267,7 @@ def main_cli_parser():
         help='Path to a BED file containing intervals to calculates cleavage '
         'proportion over.')
     cli_cleavage_profile.add_argument(
-        '-c',
-        '--chrom-sizes',
+        'chrom_sizes',
         help='A .chrom.sizes file containing chromosome names and sizes.')
     cli_cleavage_profile.add_argument(
         '-o',

--- a/src/finaletoolkit/cli/main_cli.py
+++ b/src/finaletoolkit/cli/main_cli.py
@@ -654,9 +654,9 @@ def main_cli_parser():
     cli_motifs.add_argument(
         '-min',
         '--min-length',
-        default=0,
+        default=50,
         type=int,
-        help='Minimum length for a fragment to be included.'
+        help='Minimum length for a fragment to be included. Default is 50'
         )
     cli_motifs.add_argument(
         '-max',
@@ -729,9 +729,9 @@ def main_cli_parser():
     cli_interval_motifs.add_argument(
         '-min',
         '--min-length',
-        default=0,
+        default=50,
         type=int,
-        help='Minimum length for a fragment to be included.'
+        help='Minimum length for a fragment to be included. Default is 50.'
         )
     cli_interval_motifs.add_argument(
         '-max',
@@ -813,9 +813,9 @@ def main_cli_parser():
     cli_breakpoint.add_argument(
         '-min',
         '--min-length',
-        default=0,
+        default=50,
         type=int,
-        help='Minimum length for a fragment to be included.'
+        help='Minimum length for a fragment to be included. Default is 50'
         )
     cli_breakpoint.add_argument(
         '-max',
@@ -888,9 +888,9 @@ def main_cli_parser():
     cli_interval_breakpoint.add_argument(
         '-min',
         '--min-length',
-        default=0,
+        default=50,
         type=int,
-        help='Minimum length for a fragment to be included.'
+        help='Minimum length for a fragment to be included. Default is 50.'
         )
     cli_interval_breakpoint.add_argument(
         '-max',

--- a/src/finaletoolkit/cli/main_cli.py
+++ b/src/finaletoolkit/cli/main_cli.py
@@ -794,124 +794,124 @@ def main_cli_parser():
     cli_interval_motifs.set_defaults(module='finaletoolkit.frag._end_motifs', func='interval_end_motifs')
 
     # breakpoint-motifs
-    cli_motifs = subparsers.add_parser(
+    cli_breakpoint = subparsers.add_parser(
         'breakpoint-motifs',
         prog='finaletoolkit-breakpoint-motifs',
         description="Measures frequency of k-mer breakpoint motifs.")
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         'input_file',
         help='Path to a BAM/CRAM/Fragment file containing fragment data.')
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         'refseq_file',
         help='The .2bit file for the associate reference genome sequence used '
         'during alignment.')
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-k',
         default=6,
         type=int,
         help='Length of k-mer.')
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-min',
         '--min-length',
         default=0,
         type=int,
         help='Minimum length for a fragment to be included.'
         )
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-max',
         '--max-length',
         default=None,
         type=int,
         help='Maximum length for a fragment to be included.'
         )
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-B',
         '--no-both-strands',
         action="store_false",
         dest="both_strands",
         help="Set flag to only consider one strand for breakpoint-motifs."
     )
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-n',
         '--negative-strand',
         action="store_true",
         help="Set flag in conjunction with -B to only consider 5' breakpoint motifs "
         "on the negative strand."
     )
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-o',
         '--output-file',
         default='-',
         help='TSV to print k-mer frequencies. If "-", will write to stdout.')
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-q',
         '--quality-threshold',
         default=20,
         type=int,
         help='Minimum mapping quality threshold.')
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-w',
         '--workers',
         default=1,
         type=int,
         help='Number of worker processes.')
-    cli_motifs.add_argument(
+    cli_breakpoint.add_argument(
         '-v',
         '--verbose',
         default=0,
         action='count',
         help='Enable verbose mode to display detailed processing information.')
-    cli_motifs.set_defaults(module='finaletoolkit.frag._breakpoint_motifs', func='breakpoint_motifs')
+    cli_breakpoint.set_defaults(module='finaletoolkit.frag._breakpoint_motifs', func='breakpoint_motifs')
 
     # interval-breakpoint-motifs
-    cli_interval_motifs = subparsers.add_parser(
+    cli_interval_breakpoint = subparsers.add_parser(
         'interval-breakpoint-motifs',
         prog='finaletoolkit-interval-ebreakpointnd-motifs',
         description="Measures frequency of k-mer 5' breakpoint motifs in each region "
         "specified in a BED file and writes data into a table.")
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         'input_file',
         help='Path to a BAM/CRAM/Fragment file containing fragment data.')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         'refseq_file',
         help='The .2bit file for the associate reference genome sequence used '
         'during alignment.')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         'intervals',
         help='Path to a BED file containing intervals to retrieve breakpoint motif '
         'frequencies over.')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-k',
-        default=4,
+        default=6,
         type=int,
         help='Length of k-mer.')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-min',
         '--min-length',
         default=0,
         type=int,
         help='Minimum length for a fragment to be included.'
         )
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-max',
         '--max-length',
         default=None,
         type=int,
         help='Maximum length for a fragment to be included.'
         )
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-lo',
         '--fraction-low',
         type=int,
         dest='min_length',
         help='Deprecated alias for --min-length')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-hi',
         '--fraction-high',
         type=int,
         dest='max_length',
         help='Deprecated alias for --max-length')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-B',
         '--single-strand',
         action="store_false",
@@ -920,37 +920,37 @@ def main_cli_parser():
         " the positive strand is calculated, but with the -n flag, the "
         "5' breakpoint motifs of the negative strand are considered instead."
     )
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-n',
         '--negative-strand',
         action="store_true",
         help="Set flag in conjunction with -B to only consider 5' breakpoint motifs "
         "on the negative strand."
     )
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-o',
         '--output-file',
         default='-',
         help="Path to TSV or CSV file to write breakpoint motif frequencies to.")
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-q',
         '--quality-threshold',
         default=20,
         type=int,
         help='Minimum mapping quality threshold.')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-w',
         '--workers',
         default=1,
         type=int,
         help='Number of worker processes.')
-    cli_interval_motifs.add_argument(
+    cli_interval_breakpoint.add_argument(
         '-v',
         '--verbose',
         default=0,
         action='count',
         help='Enable verbose mode to display detailed processing information.')
-    cli_interval_motifs.set_defaults(module='finaletoolkit.frag._breakpoint_motifs', func='interval_breakpoint_motifs')
+    cli_interval_breakpoint.set_defaults(module='finaletoolkit.frag._breakpoint_motifs', func='interval_breakpoint_motifs')
 
     # mds
     cli_mds = subparsers.add_parser(

--- a/src/finaletoolkit/cli/main_cli.py
+++ b/src/finaletoolkit/cli/main_cli.py
@@ -793,6 +793,165 @@ def main_cli_parser():
         help='Enable verbose mode to display detailed processing information.')
     cli_interval_motifs.set_defaults(module='finaletoolkit.frag._end_motifs', func='interval_end_motifs')
 
+    # breakpoint-motifs
+    cli_motifs = subparsers.add_parser(
+        'breakpoint-motifs',
+        prog='finaletoolkit-breakpoint-motifs',
+        description="Measures frequency of k-mer breakpoint motifs.")
+    cli_motifs.add_argument(
+        'input_file',
+        help='Path to a BAM/CRAM/Fragment file containing fragment data.')
+    cli_motifs.add_argument(
+        'refseq_file',
+        help='The .2bit file for the associate reference genome sequence used '
+        'during alignment.')
+    cli_motifs.add_argument(
+        '-k',
+        default=6,
+        type=int,
+        help='Length of k-mer.')
+    cli_motifs.add_argument(
+        '-min',
+        '--min-length',
+        default=0,
+        type=int,
+        help='Minimum length for a fragment to be included.'
+        )
+    cli_motifs.add_argument(
+        '-max',
+        '--max-length',
+        default=None,
+        type=int,
+        help='Maximum length for a fragment to be included.'
+        )
+    cli_motifs.add_argument(
+        '-B',
+        '--no-both-strands',
+        action="store_false",
+        dest="both_strands",
+        help="Set flag to only consider one strand for breakpoint-motifs."
+    )
+    cli_motifs.add_argument(
+        '-n',
+        '--negative-strand',
+        action="store_true",
+        help="Set flag in conjunction with -B to only consider 5' breakpoint motifs "
+        "on the negative strand."
+    )
+    cli_motifs.add_argument(
+        '-o',
+        '--output-file',
+        default='-',
+        help='TSV to print k-mer frequencies. If "-", will write to stdout.')
+    cli_motifs.add_argument(
+        '-q',
+        '--quality-threshold',
+        default=20,
+        type=int,
+        help='Minimum mapping quality threshold.')
+    cli_motifs.add_argument(
+        '-w',
+        '--workers',
+        default=1,
+        type=int,
+        help='Number of worker processes.')
+    cli_motifs.add_argument(
+        '-v',
+        '--verbose',
+        default=0,
+        action='count',
+        help='Enable verbose mode to display detailed processing information.')
+    cli_motifs.set_defaults(module='finaletoolkit.frag._breakpoint_motifs', func='breakpoint_motifs')
+
+    # interval-breakpoint-motifs
+    cli_interval_motifs = subparsers.add_parser(
+        'interval-breakpoint-motifs',
+        prog='finaletoolkit-interval-ebreakpointnd-motifs',
+        description="Measures frequency of k-mer 5' breakpoint motifs in each region "
+        "specified in a BED file and writes data into a table.")
+    cli_interval_motifs.add_argument(
+        'input_file',
+        help='Path to a BAM/CRAM/Fragment file containing fragment data.')
+    cli_interval_motifs.add_argument(
+        'refseq_file',
+        help='The .2bit file for the associate reference genome sequence used '
+        'during alignment.')
+    cli_interval_motifs.add_argument(
+        'intervals',
+        help='Path to a BED file containing intervals to retrieve breakpoint motif '
+        'frequencies over.')
+    cli_interval_motifs.add_argument(
+        '-k',
+        default=4,
+        type=int,
+        help='Length of k-mer.')
+    cli_interval_motifs.add_argument(
+        '-min',
+        '--min-length',
+        default=0,
+        type=int,
+        help='Minimum length for a fragment to be included.'
+        )
+    cli_interval_motifs.add_argument(
+        '-max',
+        '--max-length',
+        default=None,
+        type=int,
+        help='Maximum length for a fragment to be included.'
+        )
+    cli_interval_motifs.add_argument(
+        '-lo',
+        '--fraction-low',
+        type=int,
+        dest='min_length',
+        help='Deprecated alias for --min-length')
+    cli_interval_motifs.add_argument(
+        '-hi',
+        '--fraction-high',
+        type=int,
+        dest='max_length',
+        help='Deprecated alias for --max-length')
+    cli_interval_motifs.add_argument(
+        '-B',
+        '--single-strand',
+        action="store_false",
+        dest="both_strands",
+        help="Set flag to only consider one strand for breakpoint-motifs. By default,"
+        " the positive strand is calculated, but with the -n flag, the "
+        "5' breakpoint motifs of the negative strand are considered instead."
+    )
+    cli_interval_motifs.add_argument(
+        '-n',
+        '--negative-strand',
+        action="store_true",
+        help="Set flag in conjunction with -B to only consider 5' breakpoint motifs "
+        "on the negative strand."
+    )
+    cli_interval_motifs.add_argument(
+        '-o',
+        '--output-file',
+        default='-',
+        help="Path to TSV or CSV file to write breakpoint motif frequencies to.")
+    cli_interval_motifs.add_argument(
+        '-q',
+        '--quality-threshold',
+        default=20,
+        type=int,
+        help='Minimum mapping quality threshold.')
+    cli_interval_motifs.add_argument(
+        '-w',
+        '--workers',
+        default=1,
+        type=int,
+        help='Number of worker processes.')
+    cli_interval_motifs.add_argument(
+        '-v',
+        '--verbose',
+        default=0,
+        action='count',
+        help='Enable verbose mode to display detailed processing information.')
+    cli_interval_motifs.set_defaults(module='finaletoolkit.frag._breakpoint_motifs', func='interval_breakpoint_motifs')
+
     # mds
     cli_mds = subparsers.add_parser(
         'mds',

--- a/src/finaletoolkit/frag/__init__.py
+++ b/src/finaletoolkit/frag/__init__.py
@@ -8,3 +8,4 @@ from finaletoolkit.frag._delfi_gc_correct import delfi_gc_correct
 from finaletoolkit.frag._delfi_merge_bins import delfi_merge_bins
 from finaletoolkit.frag._adjust_wps import adjust_wps
 from finaletoolkit.frag._end_motifs import *
+from finaletoolkit.frag._breakpoint_motifs import *

--- a/src/finaletoolkit/frag/_breakpoint_motifs.py
+++ b/src/finaletoolkit/frag/_breakpoint_motifs.py
@@ -663,8 +663,8 @@ def breakpoint_motifs(
     input_file: str,
     refseq_file: str | Path,
     k: int = 6,
-    min_length: int = 10,
-    max_length: int = 600,
+    min_length: int = 50,
+    max_length: int = None,
     both_strands: bool = True,
     negative_strand: bool = False,
     output_file: None | str = None,
@@ -689,7 +689,7 @@ def breakpoint_motifs(
     k : int, optional
         Length of breakpoint motif kmer. Default is 6.
     min_length: int or None, optional
-        Minimum length of fragments to be included.
+        Minimum length of fragments to be included. Defualt is 50.
     max_length: int or None, optional
         Maximum length of fragments to be included.
     both_strands: bool
@@ -852,8 +852,8 @@ def interval_breakpoint_motifs(
     refseq_file: str | Path,
     intervals: str | Iterable[tuple[str,int,int,str]],
     k: int = 6,
-    min_length: int | None = 10,
-    max_length: int | None = 600,
+    min_length: int | None = 50,
+    max_length: int | None = None,
     both_strands: bool = True,
     negative_strand: bool = False,
     output_file: str | None = None,
@@ -879,6 +879,10 @@ def interval_breakpoint_motifs(
         (chrom, start, stop, name).
     k : int, optional
         Length of breakpoint motif kmer. Default is 6.
+    min_length: int, optional
+        Smallest fragment length accepted. Default is 50
+    max_length: int, optional
+        Longest fragment length accepted.
     both_strands: bool
         Indicate whether to calculate 5' breakpoint motifs on both positive and
         negative strands or not. If False, only 5' ends of the positive

--- a/src/finaletoolkit/frag/_breakpoint_motifs.py
+++ b/src/finaletoolkit/frag/_breakpoint_motifs.py
@@ -1,0 +1,1039 @@
+from __future__ import annotations
+from collections.abc import Iterator
+from typing import Iterable
+from multiprocessing import Pool
+from time import time
+from sys import stderr, stdout, stdin
+import gzip
+from importlib.resources import files
+from pathlib import Path
+import warnings
+
+from tqdm import tqdm
+import py2bit
+import numpy as np
+from numpy.typing import NDArray
+
+from finaletoolkit.utils.utils import frag_generator
+import finaletoolkit.frag as pkg_data
+
+class BreakpointMotifFreqs():
+    """
+    Class that stores frequencies of breakpoint-motif k-mer frequencies and
+    contains methods to manipulate this data.
+
+    Parameters
+    ----------
+    kmer_frequencies : Iterable
+        A Iterable of tuples, each containing a str representing a k-mer
+        and a float representing its frequency
+    k : int
+        Size of k-mers
+    quality_threshold: int, optional
+        Minimum mapping quality used. Default is 30.
+    """
+
+    def __init__(
+        self,
+        kmer_frequencies: Iterable[tuple[str, float]],
+        k: int,
+        quality_threshold: int = MIN_QUALITY,
+    ):
+        self.freq_dict = dict(kmer_frequencies)
+        self.k = k
+        self.quality_threshold = quality_threshold
+        if not all(len(kmer) == k for kmer, _ in kmer_frequencies):
+            raise ValueError(
+                'kmer_frequencies contains a kmer with length not equal'
+                ' to k.'
+            )
+
+    def __iter__(self) -> Iterator:
+        return ((kmer, frequency)
+                for (kmer, frequency)
+                in zip(self.kmers(), self.frequencies()))
+
+    def __len__(self) -> int:
+        return self.freq_dict.__len__()
+
+    def __str__(self) -> str:
+        return ''.join(f'{kmer}: {freq}\n' for kmer, freq in self)
+
+    def kmers(self) -> list:
+        return list(self.freq_dict.keys())
+
+    def frequencies(self) -> list:
+        return list(self.freq_dict.values())
+
+    def freq(self, kmer: str) -> float:
+        return self.freq_dict[kmer]
+
+    def to_tsv(self, output_file: str | Path, sep: str='\t'):
+        """Prints k-mer frequencies to a tsv"""
+        if isinstance(output_file, str) or isinstance(output_file, Path):
+            try:
+                # open file based on name
+                output_is_file = False
+                if output_file == '-':
+                    output = stdout
+                else:
+                    output_is_file = True
+                    output = open(output_file, 'w')
+
+                # write to file
+                for kmer, freq in self:
+                    output.write(f'{kmer}{sep}{freq}\n')
+
+            finally:
+                if output_is_file:
+                    output.close()
+        else:
+            raise TypeError('output_file must be a string or path.')
+
+    def motif_diversity_score(self) -> float:
+        """
+        Calculates a motif diversity score (MDS) using normalized
+        Shannon entropy as described by Jiang et al (2020). This
+        function is generalized for any k instead of just 6-mers.
+        """
+        num_kmers = 4**self.k
+        freq = np.array(self.frequencies())
+        # if freq is 0, ignore
+        mds = -np.sum(
+            freq * np.log(
+                freq, out=np.zeros_like(freq, dtype=np.float64),
+                where=(freq!=0)) / np.log(num_kmers))
+        return mds
+
+    @classmethod
+    def from_file(
+            cls,
+            file_path: str | Path,
+            quality_threshold: int,
+            sep: str='\t',
+            header: int=0,) -> BreakpointMotifFreqs:
+        """
+        Reads kmer frequency from a two-column tab-delimited file.
+
+        Parameters
+        ---------
+        file_path : str
+            Path string containing path to file.
+        sep : str, optional
+            Delimiter used in file.
+        header : int, optional
+            Number of lines to ignore at the head of the file.
+
+        Return
+        ------
+        kmer_freqs : BreakpointMotifFreqs
+        """
+        try:
+            # open file
+            is_file = False
+            if str(file_path).endswith('gz'):
+                is_file = True
+                file = gzip.open(file_path, 'rt')
+            elif str(file_path) == '-':
+                file = stdin
+            else:
+                is_file = True
+                file = open(file_path, 'rt')
+
+            # ignore header
+            for _ in range(header):
+                file.readline()
+
+            freq_list = []
+            lines = file.readlines()
+            line = lines[header].split(sep)
+            k = len(line[0])    # infer k from first entry
+
+            for line in lines:
+                line_data = line.split(sep)
+                if len(line_data) != 2:
+                    break
+                freq_list.append((line_data[0], float(line_data[1])))
+                if k != len(line_data[0]):
+                    raise RuntimeError(
+                        'File contains k-mers of inconsistent length.'
+                    )
+            if length := len(freq_list) != 4**k:
+                raise RuntimeError(
+                    f'File contains {length} {k}-mers instead of the expected'
+                    f' {4**k} {k}-mers.'
+                )
+        finally:
+            if is_file:
+                file.close()
+        return cls(freq_list, k, quality_threshold)
+
+
+class BreakpointMotifsIntervals():
+    """
+    Class that stores frequencies of breakpoint-motif k-mers over
+    user-specified intervals and contains methods to manipulate this
+    data.
+
+    Parameters
+    ----------
+    intervals : list
+        A list of tuples, each containing a tuple representing
+        a genomic interval (chrom, 0-based start, 1-based stop) and a
+        dict that maps kmers to frequencies in the interval.
+    k : int
+        Size of k-mers
+    quality_threshold: int, optional
+        Minimum mapping quality used. Default is 30.
+    """
+
+    def __init__(
+        self,
+        intervals: list[tuple[tuple, dict]],
+        k: int,
+        quality_threshold: int = MIN_QUALITY,
+    ):
+        self.intervals = intervals
+        self.k = k
+        self.quality_threshold = quality_threshold
+        if not all(len(freqs) == 4**k for _, freqs in intervals):
+            raise ValueError(
+                'bins contains results for kmer with length not equal'
+                ' to k.'
+            )
+
+    def __iter__(self) -> Iterator:
+        return (interval for interval in self.intervals)
+
+    def __len__(self) -> int:
+        return self.intervals.__len__()
+
+    def __str__(self) -> str:
+        return f'BreakpointMotifsIntervals over {len(self.intervals)} intervals.'
+    
+    @classmethod
+    def from_file(
+            cls,
+            file_path: str,
+            quality_threshold: int,
+            sep: str = ',',
+            header: int = 0,) -> BreakpointMotifsIntervals:
+        """
+        Reads kmer frequency from a tab-delimited file. Expected columns
+        are contig, start, stop, name, count, (kmers). Because
+        exporting to file includes an option to turn counts to a fraction,
+        this doesn't perfectly correspond to replicating the other file.
+
+        Parameters
+        ---------
+        file_path : str
+            Path string containing path to file.
+        quality_threshold : int
+            MAPQ filter used. Only used for some calculations.
+        sep : str, optional
+            Delimiter used in file.
+
+        Return
+        ------
+        kmer_freqs : BreakpointMotifsIntervals
+        """
+        try:
+            # open file
+            is_file = False
+            if file_path.endswith('gz'):
+                is_file = True
+                file = gzip.open(file_path, 'wt')
+            elif file_path == '-':
+                file = stdin
+            else:
+                is_file = True
+                file = open(file_path)
+                
+            # ignore header
+            for _ in range(header):
+                file.readline()
+
+            intervals = []
+            lines = file.readlines()
+            _,_,_,_,_,*kmers = lines[0].split(sep)
+            k = round(np.log(len(kmers))/np.log(4))
+            assert 4**k == len(kmers), f"k={k} but should be {len(kmers)}."
+
+            for line in lines[1:]:
+                contig, start, stop, name, count, *freqs = line.split(sep)
+                start, stop = int(start), int(stop)
+                float_freqs = [float(freq) for freq in freqs]
+                dict_freqs = dict(zip(kmers, float_freqs))
+                intervals.append(((contig, start, stop, name), dict_freqs))
+        finally:
+            if is_file:
+                file.close()
+        return cls(intervals, k, quality_threshold)
+
+    def freq(self, kmer: str) -> dict[tuple[str, int, int], float]:
+        """
+        Returns a list of intervals and associated frquency for given
+        kmer. Results are in the form (chrom, 0-based start, 1-based
+        stop, frequency).
+        """
+        return dict(
+            [(*interval, freq[kmer]) for interval, freq in self.intervals]
+        )
+
+    def motif_diversity_score(self) -> list[tuple[tuple, float]]:
+        """
+        Calculates a motif diversity score (MDS) for each interval using
+        normalized Shannon entropy as described by Jiang et al (2020). This
+        function is generalized for any k instead of just 6-mers.
+        """
+        num_kmers = 4**self.k
+        mds = []
+        for interval, kmers in self.intervals:
+            counts = np.array(list(kmers.values()))
+            freq = counts / np.sum(counts)
+            try:
+                interval_mds = -np.sum(
+                    freq * np.log(
+                        freq, out=np.zeros_like(freq, dtype=np.float64), where=(freq!=0)
+                        ) / np.log(num_kmers))
+            except RuntimeWarning:
+                interval_mds = np.nan
+            mds.append((interval, interval_mds))
+        return mds
+
+    def mds_bed(self, output_file: str | Path, sep: str='\t'):
+        """Writes MDS for each interval to a bed/bedgraph file."""
+        mds = self.motif_diversity_score()
+        with open(output_file, 'w') as out:
+            for interval, interval_mds in mds:
+                contig, start, stop, name = interval
+                temp_str = sep.join(
+                        [contig, str(start), str(stop), name, str(interval_mds)]
+                    )
+                out.write(
+                    f"{temp_str}\n"
+                )
+    
+    def to_tsv(
+            self,
+            output_file: str | Path,
+            calc_freq: bool=True, sep: str='\t'):
+        """
+        Writes all intervals and associated frquencies to file. Columns
+        are contig, start, stop, name, count, (kmers).
+        
+        Parameters
+        ----------
+        output_file: str
+            File to write frequencies to.
+        calc_freq: bool, optional
+            Calculates frequency of motifs if true. Otherwise, writes counts
+            for each motif. Default is true.
+        sep: str, optional
+            Separator for table. Tab-separated by default.
+        """
+        if isinstance(output_file, str) or isinstance(output_file, Path):
+            try:
+                # open file based on name
+                output_is_file = False
+                if str(output_file) == '-':
+                    output = stdout
+                else:
+                    output_is_file = True
+                    output = open(output_file, 'w')
+
+                # write to file
+                kmers = _gen_kmers(self.k, 'ACGT')
+                # header
+                output.write(sep.join(['contig','start','stop','name','count',*kmers]))
+                output.write('\n')
+                # data
+                for interval, freqs in self.intervals:
+                    count = sum(freqs.values())
+                    output.write(
+                        sep.join([
+                            interval[0],
+                            str(interval[1]),
+                            str(interval[2]),
+                            str(interval[3]),
+                            str(count), 
+                            *([str(freq) for freq in freqs.values()]
+                             if not calc_freq
+                             else [f"{(freq/count):.6f}"
+                                   if count!=0
+                                   else "NaN" 
+                                for freq
+                                in freqs.values()])
+                        ])
+                    )
+                    output.write('\n')
+
+            finally:
+                if output_is_file:
+                    output.close()
+        else:
+            raise TypeError('output_file must be a string or path.')
+    
+    def to_bedgraph(
+            self,
+            kmer: str,
+            output_file: str | Path,
+            calc_freq: bool=True,
+            sep: str='\t'
+        ):
+        """
+        Take frequency of specified kmer and writes to bedgraph.
+        
+        Parameters
+        ----------
+        output_file: str
+            File to write frequencies to.
+        calc_freq: bool, optional
+            Calculates frequency of motifs if true. Otherwise, writes counts
+            for each motif. Default is true.
+        sep: str, optional
+            Separator for table. Tab-separated by default.
+        """
+        if isinstance(output_file, str) or isinstance(output_file, Path):
+            try:
+                # open file based on name
+                output_is_file = False
+                if str(output_file) == '-':
+                    output = stdout
+                else:
+                    output_is_file = True
+                    output = open(output_file, 'w')
+
+                # write to file
+                for interval, freqs in self.intervals:
+                    count = sum(freqs.values())
+                    output.write(
+                        sep.join([
+                            interval[0],
+                            str(interval[1]),
+                            str(interval[2]),
+                            (freqs[kmer] if not calc_freq
+                             else f"{(freqs[kmer]/count):.6f}"
+                                if count!=0
+                                else "NaN"
+                            )
+                        ])
+                    )
+                    output.write('\n')
+
+            finally:
+                if output_is_file:
+                    output.close()
+        else:
+            raise TypeError('output_file must be a string.')
+        
+    def to_bed(
+            self,
+            kmer: str,
+            output_file: str | Path,
+            calc_freq: bool=True,
+            sep: str='\t'
+        ):
+        """
+        Take frequency of specified kmer and writes to BED.
+        
+        Parameters
+        ----------
+        output_file: str
+            File to write frequencies to.
+        calc_freq: bool, optional
+            Calculates frequency of motifs if true. Otherwise, writes counts
+            for each motif. Default is true.
+        sep: str, optional
+            Separator for table. Tab-separated by default.
+        """
+        if isinstance(output_file, str) or isinstance(output_file, Path):
+            try:
+                # open file based on name
+                output_is_file = False
+                if str(output_file) == '-':
+                    output = stdout
+                else:
+                    output_is_file = True
+                    output = open(output_file, 'w')
+
+                # write to file
+                for interval, freqs in self.intervals:
+                    count = sum(freqs.values())
+                    output.write(
+                        sep.join([
+                            interval[0],
+                            str(interval[1]),
+                            str(interval[2]),
+                            interval[3],
+                            (freqs[kmer] if not calc_freq
+                             else f"{(freqs[kmer]/count):.6f}"
+                                if count!=0
+                                else "NaN"
+                            )
+                        ])
+                    )
+                    output.write('\n')
+
+            finally:
+                if output_is_file:
+                    output.close()
+        else:
+            raise TypeError('output_file must be a string.')
+
+
+def _gen_kmers(k: int, bases: str) -> list:
+        """Function to recursively create a list of k-mers."""
+        if k == 1:
+            return [base for base in bases]
+        else:
+            kmers = []
+            for k_minus_mer in _gen_kmers(k-1, bases):
+                for base in bases:
+                    kmers.append(k_minus_mer+base)
+            return kmers
+
+
+def _reverse_complement(kmer: str) -> str:
+    reversed = kmer[-1::-1]
+    pair_dict = {'A': 'T',
+                 'T': 'A',
+                 'G': 'C',
+                 'C': 'G'}
+    complemented = ''.join(pair_dict[base] for base in reversed)
+    return complemented
+
+
+def region_breakpoint_motifs(
+    input_file: str,
+    contig: str,
+    start: int,
+    stop: int,
+    refseq_file: str | Path,
+    k: int = 6,
+    fraction_low: int = 10,
+    fraction_high: int = 600,
+    both_strands: bool = True,
+    negative_strand: bool = False,
+    output_file: str | None = None,
+    quality_threshold: int = 30,
+    verbose: bool | int = False,
+) -> dict:
+    """
+    Function that reads fragments in the specified region from a BAM,
+    CRAM, or tabix indexed fragment file and returns the  breakpoint motif
+    counts as a dictionary.
+
+    Parameters
+    ----------
+    input_file : str
+        Path of BAM, CRAM, or Frag.gz containing pair-end reads.
+    contig : str
+        Name of contig or chromosome for region.
+    start : int
+        0-based start coordinate.
+    stop : int
+        1-based end coordinate.
+    refseq_file : str or Path
+        2bit file with reference sequence `input_file` was aligned to.
+    k : int, optional
+        Length of breakpoint motif kmer. Default is 6.
+    fraction_low: int, optional
+        Minimum fragment length.
+    fraction_high: int, optional
+        Maximum fragment length.
+    both_strands: bool, optional
+        Choose whether to use forward 5' ends only or use 5' ends for
+        both ends of PE reads. If `negative_strand` is True, only
+        reverse 5' ends are used.
+    negative_strand: bool
+        Only considered if the `both_strands` option is False. When set 
+        to True, only ends on the negative strand are considered.
+    output_file : None or str, optional
+        Ignored.
+    quality_threshold : int, optional
+    verbose : bool or int, optional
+
+    Return
+    ------
+    breakpoint_motif_freq : dict
+    """
+
+    if verbose:
+        start_time = time()
+        
+    if both_strands and negative_strand:
+        raise ValueError(
+            'Cannot have both both_strands and negative_strand.')
+
+    # iterable of fragments
+    frag_ends = frag_generator(
+        input_file,
+        contig,
+        quality_threshold,
+        start,
+        stop,
+        min_length=fraction_low,
+        max_length=fraction_high,
+    )
+    # create dict where keys are kmers and values are counts
+    bases='ACGT'
+    kmer_list = _gen_kmers(k, bases)
+    breakpoint_motif_counts = dict(zip(kmer_list, 4**k*[0]))
+
+    # TODO: accept other reference file types e.g. FASTA
+    # count breakpoint motifs
+    try:
+        refseq = py2bit.open(str(refseq_file), 'r')
+        if both_strands:   # both strands of fragment
+            for frag in frag_ends:
+                # py2bit uses 0-based for start, 1-based for end
+                # forward breakpoint-motif
+                forward_kmer = refseq.sequence(
+                    contig, int(frag[1]-(k/2)), int(frag[1]+(k/2))
+                )
+                assert len(forward_kmer) == k    
+
+                if 'N' not in forward_kmer:
+                    breakpoint_motif_counts[forward_kmer] += 1
+                    
+                # reverse breakpoint-motif
+                reverse_kmer = refseq.sequence(
+                    contig, int(frag[2]-(k/2)), int(frag[2]+(k/2))
+                )
+                assert len(reverse_kmer) == k
+
+                if 'N' not in reverse_kmer:
+                    breakpoint_motif_counts[_reverse_complement(reverse_kmer)] += 1
+        else:
+            for frag in frag_ends:
+                if frag[4] and not negative_strand:  # is on indicated strand
+                    # py2bit uses 0-based for start, 1-based for end
+                    # forward end-motif
+                    forward_kmer = refseq.sequence(
+                        contig, int(frag[1]-(k/2)), int(frag[1]+(k/2))
+                    )
+                    assert len(forward_kmer) == k    
+
+                    if 'N' not in forward_kmer:
+                        breakpoint_motif_counts[forward_kmer] += 1
+                    
+                elif negative_strand:
+                    # reverse end-motif
+                    try:
+                        reverse_kmer = refseq.sequence(
+                            contig, int(frag[2]-(k/2)), int(frag[2]+(k/2))
+                        )
+                        assert len(reverse_kmer) == k
+
+                        if 'N' not in reverse_kmer:
+                            reverse_kmer = refseq.sequence(
+                                contig, int(frag[2]-(k/2)), int(frag[2]+(k/2))
+                            )
+                            breakpoint_motif_counts[rc_reverse_kmer] += 1
+                    except RuntimeError:
+                        if verbose > 1:
+                            stderr.write(
+                                f'Attempt to read interval at {contig}:'
+                                f'{int(frag[2]-k)}-{int(frag[2])} failed.'
+                                'Skipping.')
+                        continue
+
+    finally:
+        refseq.close()
+
+    if verbose:
+        stop_time = time()
+        stderr.write(
+            f'region_breakpoint_motifs took {stop_time-start_time} seconds to run\n'
+        )
+
+    return breakpoint_motif_counts
+
+
+def _region_breakpoint_motifs_star(args) -> NDArray[np.float64]:
+    results_dict = region_breakpoint_motifs(*args)
+    return np.array(list(results_dict.values()), dtype='<f8')
+
+
+def _region_breakpoint_motifs_dict_star(args) -> dict:
+    results_dict = region_breakpoint_motifs(*args)
+    return results_dict
+
+
+def breakpoint_motifs(
+    input_file: str,
+    refseq_file: str | Path,
+    k: int = 6,
+    min_length: int = 10,
+    max_length: int = 600,
+    both_strands: bool = True,
+    negative_strand: bool = False,
+    output_file: None | str = None,
+    quality_threshold: int = 30,
+    workers: int = 1,
+    verbose: bool | int = False,
+    fraction_low: int | None = None,
+    fraction_high: int | None = None,
+) -> BreakpointMotifFreqs:
+    """
+    Function that reads fragments from a BAM, CRAM, or tabix indexed
+    file and returns the 5' k-mer (default is 6-mer) breakpoint motif
+    frequencies as a dictionary. Optionally writes data to a tsv.
+
+    Parameters
+    ----------
+    input_file : str
+        BAM, CRAM, or Frag.gz file with paired-end reads.
+    refseq_file : str or Path
+        2bit file with sequence of reference genome input_file is
+        aligned to.
+    k : int, optional
+        Length of breakpoint motif kmer. Default is 6.
+    min_length: int or None, optional
+        Minimum length of fragments to be included.
+    max_length: int or None, optional
+        Maximum length of fragments to be included.
+    both_strands: bool
+        Indicate whether to calculate 5' breakpoint motifs on both positive and
+        negative strands or not. If False, only 5' ends of the positive
+        strand are considered, unless the `negative_strand` option is
+        set to True. Default is True. 
+    negative_strand: bool
+        Only considered if the `both_strands` option is False. When set 
+        to True, only ends on the negative strand are considered.
+    output_file : None or str, optional
+        File path to write results to. Either tsv or csv. Default is
+        None.
+    quality_threshold : int, optional
+        Minimum MAPQ to filter. Default is 30.
+    workers : int, optional
+        Number of worker processes. Default is 1.
+    verbose : bool or int, optional
+    fraction_low : int or None, optional
+        Alias for `min_length`. *Deprecated.*
+    fraction_high : int or None, optional
+        Alias for `max_length`. *Deprecated.*
+    Return
+    ------
+    breakpoint_motif_freq : BreakpointMotifFreqs
+    """
+    if verbose:
+        start_time = time()
+        tqdm.write(
+            f"""
+            input_file: {input_file}
+            refseq_file: {refseq_file}
+            k: {k}
+            min_length: {min_length}
+            max_length: {max_length}
+            both_strands: {both_strands}
+            output_file: {output_file}
+            quality_threshold: {quality_threshold}
+            workers: {workers}
+            verbose: {verbose}
+            """
+        )
+
+    # Pass aliases and check for conflicts
+    if fraction_low is not None and min_length is None:
+        min_length = fraction_low
+        warnings.warn("fraction_low is deprecated. Use min_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+    elif fraction_low is not None and min_length is not None:
+        warnings.warn("fraction_low is deprecated. Use min_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        raise ValueError(
+            'fraction_low and min_length cannot both be specified')
+
+    if fraction_high is not None and max_length is None:
+        max_length = fraction_high
+        warnings.warn("fraction_high is deprecated. Use max_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+    elif fraction_high is not None and max_length is not None:
+        warnings.warn("fraction_high is deprecated. Use max_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        raise ValueError(
+            'fraction_high and max_length cannot both be specified')
+
+    # getting possible kmers
+    bases = 'ACGT'
+    kmer_list = _gen_kmers(k, bases)
+
+    # read chromosomes from py2bit
+    try:
+        refseq = py2bit.open(str(refseq_file), 'r')
+        chroms: dict = refseq.chroms()
+    finally:
+        refseq.close()
+
+    # generate list of inputs
+    intervals = []
+    window_size = 1000000
+    for chrom, chrom_length in chroms.items():
+        for start in range(0, chrom_length, window_size):
+            intervals.append((
+                input_file,
+                chrom,
+                start,
+                start+window_size,
+                refseq_file,
+                k,
+                min_length,
+                max_length,
+                both_strands,
+                negative_strand, 
+                None,
+                quality_threshold,
+                verbose - 2 if verbose > 2 else 0
+            ))
+        intervals.append((
+            input_file,
+            chrom,
+            chrom_length - chrom_length%window_size,
+            chrom_length,
+            refseq_file,
+            k,
+            min_length,
+            max_length,
+            both_strands,
+            negative_strand,
+            None,
+            quality_threshold,
+            verbose - 2 if verbose > 2 else 0
+        ))
+
+    # use process pool to count kmers
+    try:
+        # open pool
+        pool = Pool(workers)
+
+        # uses tqdm loading bar if verbose == True
+        counts_iter = pool.imap(
+            _region_breakpoint_motifs_star,
+            tqdm(intervals, 'Reading 1mb windows', position=0)if verbose else intervals,
+            chunksize=min(int(len(intervals)/workers/2+1), 1000)
+        )
+
+        ccounts = np.zeros((4**k,), np.float64)
+        for count in tqdm(counts_iter, 'Counting breakpoint-motifs', len(intervals), position=1) if verbose else counts_iter:
+            ccounts = ccounts + count
+
+    finally:
+        pool.close()
+
+    frequencies = ccounts/np.sum(ccounts)
+
+    results = BreakpointMotifFreqs(
+        zip(kmer_list, frequencies),
+        k,
+        quality_threshold,
+    )
+
+    if output_file is not None:
+        if output_file.endswith('.csv'):
+            results.to_tsv(output_file, sep=',')
+        else:
+            results.to_tsv(output_file)
+
+    if verbose:
+        stop_time = time()
+        tqdm.write(
+            f'breakpoint_motifs took {stop_time-start_time} seconds to run\n'
+        )
+
+    return results
+
+
+def interval_breakpoint_motifs(
+    input_file: str,
+    refseq_file: str | Path,
+    intervals: str | Iterable[tuple[str,int,int,str]],
+    k: int = 6,
+    min_length: int | None = 10,
+    max_length: int | None = 600,
+    both_strands: bool = True,
+    negative_strand: bool = False,
+    output_file: str | None = None,
+    quality_threshold: int = 30,
+    workers: int = 1,
+    verbose: bool | int = False,
+    fraction_low: int | None = None,
+    fraction_high: int | None = None,
+) -> BreakpointMotifsIntervals:
+    """
+    Function that reads fragments from a BAM, CRAM, or tabix indexed
+    file and user-specified intervals and returns the 5' k-mer
+    (default is 6-mer) breakpoint motif. Optionally writes data to a tsv.
+
+    Parameters
+    ----------
+    input_file : str
+        Path of BAM, CRAM, or Frag.gz containing pair-end reads.
+    refseq_file : str or Path
+        Path of 2bit file for reference genome that reads are aligned to.
+    intervals : str or tuple
+        Path of BED file containing intervals or list of tuples
+        (chrom, start, stop, name).
+    k : int, optional
+        Length of breakpoint motif kmer. Default is 6.
+    both_strands: bool
+        Indicate whether to calculate 5' breakpoint motifs on both positive and
+        negative strands or not. If False, only 5' ends of the positive
+        strand are considered, unless the `negative_strand` option is
+        set to True. Default is True. 
+    negative_strand: bool
+        Only considered if the `both_strands` option is False. When set 
+        to True, only ends on the negative strand are considered.
+    output_file : None or str, optional
+        File path to write results to. Either tsv or csv.
+    quality_threshold : int, optional
+        Minimum MAPQ to filter.
+    workers : int, optional
+        Number of worker processes.
+    verbose : bool or int, optional
+
+    Return
+    ------
+    breakpoint_motif_freq : BreakpointMotifIntervals
+    """
+    if verbose:
+        start_time = time()
+        
+     # Pass aliases and check for conflicts
+    if fraction_low is not None and min_length is None:
+        min_length = fraction_low
+        warnings.warn("fraction_low is deprecated. Use min_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+    elif fraction_low is not None and min_length is not None:
+        warnings.warn("fraction_low is deprecated. Use min_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        raise ValueError(
+            'fraction_low and min_length cannot both be specified')
+
+    if fraction_high is not None and max_length is None:
+        max_length = fraction_high
+        warnings.warn("fraction_high is deprecated. Use max_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+    elif fraction_high is not None and max_length is not None:
+        warnings.warn("fraction_high is deprecated. Use max_length instead.",
+                      category=DeprecationWarning,
+                      stacklevel=2)
+        raise ValueError(
+            'fraction_high and max_length cannot both be specified')
+
+    bases='ACGT'
+    kmer_list = _gen_kmers(k, bases)
+
+    # generate list of inputs
+    if type(intervals) is str:
+        with open(intervals, 'r') as interval_file:
+            intervals_tuples = [    # parses file lines into a tuple generator
+                (chrom, int(start), int(stop),
+                    name[0] if len(name) > 0 else '.')
+                for chrom, start, stop, *name
+                in (line.split() for line in interval_file.readlines())
+            ]
+    elif isinstance(intervals, list):
+        intervals_tuples = intervals
+    else:
+        raise TypeError("Intervals should be string or list.")
+    
+    mp_intervals = []   # args to be fed into pool processes
+    for chrom, start, stop, *_ in intervals_tuples:
+        mp_intervals.append((
+            input_file,
+            chrom,
+            start,
+            stop,
+            refseq_file,
+            k,
+            min_length,
+            max_length,
+            both_strands,
+            negative_strand,
+            None,
+            quality_threshold,
+            verbose - 2 if verbose > 2 else 0
+        )
+    )
+
+    # use process pool to aggregate kmers
+    try:
+        # open pool
+        pool = Pool(workers)
+
+        # uses tqdm loading bar if verbose == True
+        counts_iter = pool.imap(
+            _region_breakpoint_motifs_dict_star,
+            tqdm(
+                mp_intervals,
+                'Reading intervals',
+                position=0) if verbose else mp_intervals,
+            chunksize=min(int(len(intervals)/workers/2+1), 1000)
+        )
+
+    finally:
+        pool.close()
+    results = BreakpointMotifsIntervals(
+        [(interval, counts)
+         for interval, counts
+         in zip(intervals_tuples, counts_iter)],
+         k,
+         quality_threshold,
+    )
+
+    if output_file is not None:
+        if output_file.endswith('.csv'):
+            results.to_tsv(output_file, sep=',')
+        else:
+            results.to_tsv(output_file)
+
+    if verbose:
+        stop_time = time()
+        tqdm.write(
+            f'breakpoint_motifs took {stop_time-start_time} seconds to run\n'
+        )
+
+    return results
+
+
+def _cli_mds(
+    file_path: str,
+    sep: str = '\t',
+    header: int = 0,
+):
+    """Function for commandline acces to MDS from a tsv file."""
+    # 30 is used as a placeholder for the quality threshold. It is not
+    # used to calculate MDS and can be ignored.
+    motifs = BreakpointMotifFreqs.from_file(
+        file_path,
+        30,
+        sep,
+        header,
+    )
+    mds = motifs.motif_diversity_score()
+    stdout.write(f'{mds}\n')
+
+def _cli_interval_mds(
+    file_path: str,
+    file_out: str,
+    sep: str = ',',
+    header: int = 0,
+):
+    # 30 is used as a placeholder for the quality threshold. It is not
+    # used to calculate MDS and can be ignored.
+    motifs = BreakpointMotifsIntervals.from_file(
+        file_path,
+        30,
+        sep,
+        header,
+    )
+    motifs.mds_bed(file_out)

--- a/src/finaletoolkit/frag/_breakpoint_motifs.py
+++ b/src/finaletoolkit/frag/_breakpoint_motifs.py
@@ -37,7 +37,7 @@ class BreakpointMotifFreqs():
         self,
         kmer_frequencies: Iterable[tuple[str, float]],
         k: int,
-        quality_threshold: int = MIN_QUALITY,
+        quality_threshold: int = 30,
     ):
         self.freq_dict = dict(kmer_frequencies)
         self.k = k
@@ -191,7 +191,7 @@ class BreakpointMotifsIntervals():
         self,
         intervals: list[tuple[tuple, dict]],
         k: int,
-        quality_threshold: int = MIN_QUALITY,
+        quality_threshold: int = 30,
     ):
         self.intervals = intervals
         self.k = k
@@ -627,9 +627,7 @@ def region_breakpoint_motifs(
                         assert len(reverse_kmer) == k
 
                         if 'N' not in reverse_kmer:
-                            reverse_kmer = refseq.sequence(
-                                contig, int(frag[2]-(k/2)), int(frag[2]+(k/2))
-                            )
+                            rc_reverse_kmer = _reverse_complement(reverse_kmer)
                             breakpoint_motif_counts[rc_reverse_kmer] += 1
                     except RuntimeError:
                         if verbose > 1:

--- a/src/finaletoolkit/frag/_breakpoint_motifs.py
+++ b/src/finaletoolkit/frag/_breakpoint_motifs.py
@@ -518,7 +518,7 @@ def region_breakpoint_motifs(
     output_file: str | None = None,
     quality_threshold: int = 30,
     verbose: bool | int = False,
-) -> dict:
+ ) -> dict:
     """
     Function that reads fragments in the specified region from a BAM,
     CRAM, or tabix indexed fragment file and returns the  breakpoint motif
@@ -673,7 +673,7 @@ def breakpoint_motifs(
     verbose: bool | int = False,
     fraction_low: int | None = None,
     fraction_high: int | None = None,
-) -> BreakpointMotifFreqs:
+ ) -> BreakpointMotifFreqs:
     """
     Function that reads fragments from a BAM, CRAM, or tabix indexed
     file and returns the 5' k-mer (default is 6-mer) breakpoint motif
@@ -773,7 +773,7 @@ def breakpoint_motifs(
     intervals = []
     window_size = 1000000
     for chrom, chrom_length in chroms.items():
-        for start in range(0, chrom_length, window_size):
+        for start in range(0, chrom_length-window_size, window_size):
             intervals.append((
                 input_file,
                 chrom,
@@ -862,7 +862,7 @@ def interval_breakpoint_motifs(
     verbose: bool | int = False,
     fraction_low: int | None = None,
     fraction_high: int | None = None,
-) -> BreakpointMotifsIntervals:
+ ) -> BreakpointMotifsIntervals:
     """
     Function that reads fragments from a BAM, CRAM, or tabix indexed
     file and user-specified intervals and returns the 5' k-mer
@@ -1007,7 +1007,7 @@ def _cli_mds(
     file_path: str,
     sep: str = '\t',
     header: int = 0,
-):
+ ):
     """Function for commandline acces to MDS from a tsv file."""
     # 30 is used as a placeholder for the quality threshold. It is not
     # used to calculate MDS and can be ignored.
@@ -1025,7 +1025,7 @@ def _cli_interval_mds(
     file_out: str,
     sep: str = ',',
     header: int = 0,
-):
+ ):
     # 30 is used as a placeholder for the quality threshold. It is not
     # used to calculate MDS and can be ignored.
     motifs = BreakpointMotifsIntervals.from_file(

--- a/src/finaletoolkit/frag/_cleavage_profile.py
+++ b/src/finaletoolkit/frag/_cleavage_profile.py
@@ -182,7 +182,7 @@ def _cleavage_profile_star(args):
 def multi_cleavage_profile(
     input_file: FragFile,
     interval_file: Union[str, Path],
-    chrom_sizes: Union[str, Path, None] = None,
+    chrom_sizes: Union[str, Path, None],
     left: int=0,
     right: int=0,
     min_length: int|None=None,

--- a/src/finaletoolkit/frag/_cleavage_profile.py
+++ b/src/finaletoolkit/frag/_cleavage_profile.py
@@ -281,7 +281,7 @@ def multi_cleavage_profile(
     
     if chrom_sizes is None:
         raise ValueError(
-            '--chrom_sizes must be specified'
+            '--chrom_sizes must be specified for tabix-indexed files.'
         )
     # get chroms
     header = chrom_sizes_to_list(chrom_sizes)
@@ -332,32 +332,6 @@ def multi_cleavage_profile(
     starts = starts[1:]
     stops = stops[1:]
 
-    # reading chrom.sizes file
-    # get chrom sizes from input_file or chrom_sizes
-    
-    if (isinstance(input_file, pysam.AlignmentFile)):
-        references = input_file.references
-        lengths = input_file.lengths
-        header = list(zip(references, lengths))
-    elif (
-            (isinstance(input_file, str)
-            or isinstance(input_file, PathLike))
-        and
-            (str(input_file).endswith('.sam')
-            or str(input_file).endswith('.bam')
-            or str(input_file).endswith('.cram'))
-    ):
-        with pysam.AlignmentFile(input_file, 'r') as bam:
-            references = bam.references
-            lengths = bam.lengths
-            header = list(zip(references, lengths))
-    elif chrom_sizes is not None:
-        header = chrom_sizes_to_list(chrom_sizes)
-    else:
-        raise ValueError(
-            'chrom_sizes must be specified for Tabix-indexed files'
-        )
-        
     size_dict = dict(header)
 
     sizes = [size_dict[contig] for contig in contigs]

--- a/src/finaletoolkit/frag/_cleavage_profile.py
+++ b/src/finaletoolkit/frag/_cleavage_profile.py
@@ -309,12 +309,14 @@ def multi_cleavage_profile(
             # parse file
             contents = line.split()
             contig = contents[0].strip()
-            if contig not in chrom_dict:
-                warnings.warn(f"Skipping {contig} (not in chrom_sizes)", UserWarning)
-                continue
             start, stop = int(contents[1]), int(contents[2])
+            if contig not in chrom_dict:
+                warnings.warn(f"Skipping interval {contig}:{start}-{stop} "
+                 f"from interval_file ({contig} not in chrom_sizes)", UserWarning)
+                continue
             start = max(0, start - left)
             stop = min(stop + right, chrom_dict[contig])
+            
 
             # if overlapping:
             if (prev_contig == contig and start < prev_stop):

--- a/src/finaletoolkit/frag/_cleavage_profile.py
+++ b/src/finaletoolkit/frag/_cleavage_profile.py
@@ -309,6 +309,9 @@ def multi_cleavage_profile(
             # parse file
             contents = line.split()
             contig = contents[0].strip()
+            if contig not in chrom_dict:
+                warnings.warn(f"Skipping {contig} (not in chrom_sizes)", UserWarning)
+                continue
             start, stop = int(contents[1]), int(contents[2])
             start = max(0, start - left)
             stop = min(stop + right, chrom_dict[contig])

--- a/src/finaletoolkit/frag/_cleavage_profile.py
+++ b/src/finaletoolkit/frag/_cleavage_profile.py
@@ -182,7 +182,7 @@ def _cleavage_profile_star(args):
 def multi_cleavage_profile(
     input_file: FragFile,
     interval_file: Union[str, Path],
-    chrom_sizes: Union[str, Path, None],
+    chrom_sizes: Union[str, Path],
     left: int=0,
     right: int=0,
     min_length: int|None=None,
@@ -281,7 +281,7 @@ def multi_cleavage_profile(
     
     if chrom_sizes is None:
         raise ValueError(
-            '--chrom_sizes must be specified for tabix-indexed files.'
+            'chrom_sizes must be specified.'
         )
     # get chroms
     header = chrom_sizes_to_list(chrom_sizes)

--- a/src/finaletoolkit/frag/_frag_length.py
+++ b/src/finaletoolkit/frag/_frag_length.py
@@ -503,7 +503,7 @@ def frag_length_intervals(
                         'suffix.'
                     )
                 output.write('contig\tstart\tstop\tname\tmean\tmedian\t'
-                             'stdev\tmin\tmax\count'
+                             'stdev\tmin\tmax\tcount'
                              '\ts150\n')   # type: ignore
                 output.write(
                     '\n'.join(

--- a/src/finaletoolkit/frag/_frag_length.py
+++ b/src/finaletoolkit/frag/_frag_length.py
@@ -503,7 +503,7 @@ def frag_length_intervals(
                         'suffix.'
                     )
                 output.write('contig\tstart\tstop\tname\tmean\tmedian\t'
-                             'stdev\tmin\tmax\tfragment_coverage'
+                             'stdev\tmin\tmax\count'
                              '\ts150\n')   # type: ignore
                 output.write(
                     '\n'.join(

--- a/src/finaletoolkit/frag/_frag_length.py
+++ b/src/finaletoolkit/frag/_frag_length.py
@@ -15,6 +15,7 @@ from matplotlib.ticker import FuncFormatter
 from finaletoolkit.utils.utils import (
     _get_intervals, frag_generator
 )
+from finaletoolkit.utils.typing import FragFile
 
 
 def plot_histogram(
@@ -95,7 +96,7 @@ def _find_median(val_freq_dict):
 
 
 def _frag_length_stats(
-    input_file: Union[str, pysam.AlignmentFile],
+    input_file: FragFile,
     contig: str,
     start: int,
     stop: int,
@@ -147,9 +148,9 @@ def frag_length(
 
     Parameters
     ----------
-    input_file : str or pysam.AlignmentFile
-        BAM, CRAM, or fragment file containing paired-end fragment reads or
-        its path. `AlignmentFile` must be opened in read mode.
+    input_file : str, AlignmentFile, or TabixFile
+        BAM, CRAM, or tabix-indexed containing paired-end fragment reads or
+        its path. pysam wrappers must be opened in read mode.
     contig : string, optional
         Contig or chromosome to get fragments from
     start : int, optional
@@ -163,7 +164,8 @@ def frag_length(
         in the interval.
         - any: any part of the fragment is in the interval.
     output_file : string, optional
-    quality_threshold : int, optional
+    quality_threshold: int, optional
+        Minimum MAPQ to accept for a fragment to be counted.
     verbose : bool, optional
 
     Returns
@@ -230,7 +232,7 @@ def frag_length(
 
 
 def frag_length_bins(
-    input_file: Union[str, pysam.AlignmentFile],
+    input_file: FragFile,
     contig: str | None = None,
     start: int | None = None,
     stop: int | None = None,
@@ -250,19 +252,40 @@ def frag_length_bins(
 
     Parameters
     ----------
-    input_file : str or AlignmentFile
+    input_file : str, AlignmentFile, or TabixFile
+        BAM, CRAM, or tabix-indexed containing paired-end fragment reads or
+        its path. pysam wrappers must be opened in read mode.
     contig : str, optional
+        If specified, limits calculations to fragments on this
+        chromosome/contig. If not specified, lengths are calculated genomewide.
     start : int, optional
+        Left-most coordinate of interval to fetch from. See intersect_policy.
+        `contig` and `stop` must be specified if a value is given for `start`.
     stop : int, optional
+        Right-most coordinate of interval to fetch from. See intersect_policy.
+        `contig` and `start` must be specified if a value is given for `stop`.
+    min_length: int, optional
+        Specifies shortest fragment length included in array.
+    max_length: int, optional
+        Specifies longest fragment length included in array.
     bin_size : int, optional
+        Specify how wide each bin is. If None, will be calculated
+        automatically.
     output_file : str, optional
-    intersect_policy : str, optional
+        tsv or tsv.gz file to write results to. Writes to stdout if "-".
+    intersect_policy: str {"midpoint", "any"}, optional
         Specifies what policy is used to include fragments in the
         given interval. Default is "midpoint". Policies include:
         - midpoint: the average of end coordinates of a fragment lies
         in the interval.
         - any: any part of the fragment is in the interval.
+    quality_threshold: int, optional
+        Minimum MAPQ to accept for a fragment to be counted.
+    histogram_path: str, optional
+        If specified, a simple histograpm will be generated using matplotlib.
     workers : int, optional
+        Number of worker processes.
+    verbose : bool, optional
 
     Returns
     -------
@@ -383,12 +406,30 @@ def frag_length_intervals(
 
     Parameters
     ----------
-    input_file : str or AlignmentFile
+    input_file : str, AlignmentFile, or TabixFile
+        BAM, CRAM, or tabix-indexed containing paired-end fragment reads or
+        its path. pysam wrappers must be opened in read mode.
     interval_file : str
+        BED format file specifying intervals over which to calculate fragment
+        length statistics for.
     output_file : str, optional
-    quality_threshold : int, optional
+        If specified, will write results in the BED or bed.gz format. Will
+        write to stdout if set to "-".
+    min_length: int, optional
+        Specifies shortest fragment length included in array.
+    max_length: int, optional
+        Specifies longest fragment length included in array.
+    quality_threshold: int, optional
+        Minimum MAPQ to accept for a fragment to be counted.
+    intersect_policy: str {"midpoint", "any"}, optional
+        Specifies what policy is used to include fragments in the
+        given interval. Default is "midpoint". Policies include:
+        - midpoint: the average of end coordinates of a fragment lies
+        in the interval.
+        - any: any part of the fragment is in the interval.
     workers : int, optional
-    verbose : bool or int, optional
+        Number of worker processes.
+    verbose : bool, optional
 
     Returns
     -------

--- a/src/finaletoolkit/frag/_multi_wps.py
+++ b/src/finaletoolkit/frag/_multi_wps.py
@@ -148,6 +148,9 @@ def multi_wps(
                 'chrom_sizes must be specified for BED/Fragment files'
             )
         header = chrom_sizes_to_list(chrom_sizes)
+        references = [chrom for (chrom, _) in header]
+
+    chrom_sizes_dict = dict(header)
 
     if (verbose > 1):
         stderr.write(f'header is {header}\n')
@@ -182,7 +185,7 @@ def multi_wps(
                     f"[multi_wps] {contig}:{contents[1]}-{contents[2]} is "
                     "invalid. Please be sure start coordinate occurs before "
                     f"stop for all intervals in {site_bed}.")
-            if contig not in chrom_dict:
+            if contig not in references:
                 warnings.warn(f"Skipping site {contig}:{int(contents[1])} from site_bed (chrom not in chrom_sizes)", UserWarning)
                 continue
             midpoint = (int(contents[1]) + int(contents[2])) // 2
@@ -209,8 +212,6 @@ def multi_wps(
     finally:
         if site_bed != '-':
             bed.close()  
-            
-    chrom_sizes_dict = dict(header)
     
     chrom_sizes_intervals = [chrom_sizes_dict[contig] for contig in contigs]
 

--- a/src/finaletoolkit/frag/_multi_wps.py
+++ b/src/finaletoolkit/frag/_multi_wps.py
@@ -182,6 +182,9 @@ def multi_wps(
                     f"[multi_wps] {contig}:{contents[1]}-{contents[2]} is "
                     "invalid. Please be sure start coordinate occurs before "
                     f"stop for all intervals in {site_bed}.")
+            if contig not in chrom_dict:
+                warnings.warn(f"Skipping site {contig}:{int(contents[1])} from site_bed (chrom not in chrom_sizes)", UserWarning)
+                continue
             midpoint = (int(contents[1]) + int(contents[2])) // 2
 
             start = max(0, midpoint + int(left_of_site))

--- a/src/finaletoolkit/utils/utils.py
+++ b/src/finaletoolkit/utils/utils.py
@@ -269,7 +269,8 @@ def frag_generator(
             else:
                 raise ValueError(
                     f"{input_file} is not an accepted file type. Only "
-                    "CRAM, BAM, and Frag.gz files are accepted.")
+                    "CRAM, BAM, and tabix-indexed gzipped bed-style "
+                    "files are accepted.")
         elif type(input_file) == pysam.AlignmentFile:
             input_file_is_path = False
             is_sam = True

--- a/src/finaletoolkit/utils/utils.py
+++ b/src/finaletoolkit/utils/utils.py
@@ -227,11 +227,9 @@ def frag_generator(
     stop : int, optional
         Right-most coordinate of interval to fetch from. See intersect_policy.
     min_length : int, optional
-        Specifies lowest fragment length included in array. Default is
-        120, equivalent to long fraction.
+        Specifies lowest fragment length included in array.
     max_length : int, optional
-        Specifies highest fragment length included in array. Default is
-        120, equivalent to long fraction.
+        Specifies highest fragment length included in array.
     intersect_policy : str, optional
         Specifies what policy is used to include fragments in the
         given interval. Default is "midpoint". Policies include:

--- a/src/finaletoolkit/version.py
+++ b/src/finaletoolkit/version.py
@@ -2,4 +2,4 @@
 Single-source module for the package version number.
 """
 
-__version__ = "0.10.7"
+__version__ = "0.11.0"


### PR DESCRIPTION
### Added
- Breakpoint motifs, which are described in Guo et al. (doi.org/10.1016/j.ebiom.2022.104131).
    - Added `finaletoolkit breakpoint-motifs' and `finaletoolkit interval-breakpoint-motifs' CLI subcommands
    - Added `BreakpointMotifFreqs`, `BreakpointMotifIntervals`, `region_breakpoint_motifs`, `breakpoint_motifs`, and `interval_breakpoint_motifs` to `finaletoolkit.frag` Python API
- Added `count` and `S150` columns to the results of frag_length_intervals

### Changed
- `chrom.sizes` file is now required for `finaletoolkit cleavage-profile`
- Default for  `min_length` or `fraction_low` for end-motif related functions are now 50.

### Fixed
- WPS and cleavage-profile check for intervals in the user-provided bed to see if they are present in the user-provided fragment file. Instead of throwing an exception when this occurs, now the program only issues a warning and continues to the next interval.
- Updated various docstrings.
- Fixed issue in end-motif functions where `min_length<k` led to inexplicable errors. Now a warning is issued in this case, and `min_length` is set to `k`.
- Fixed issue in `end-motifs` where the last interval is repeated, potentially beyond the end of the chromosome.