### PR TITLE
Update build-docs.yml

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,14 +21,14 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build-and-commit-docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11' 
 
@@ -45,36 +45,9 @@ jobs:
         run: |
           make -C docs html
 
-      - name: Commit and push built HTML
-        # Run on push, not if the bot is the committer so no loops
-        if: github.event_name == 'push' && github.actor != 'github-actions[bot]'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          
-          git add docs/_build/html/
-          
-          # Only commit w/ actual changes
-          if ! git diff --staged --quiet; then
-            git commit -m "docs: Regenerate Sphinx HTML for ${{ github.sha }} [ci skip]"
-            echo "Pushing doc changes..."
-            git push origin ${{ github.ref_name }}
-          else
-            echo "No changes to commit in docs/_build/html."
-          fi
-          
-      #  pages deployment
-      - name: Setup Pages
-        if: github.ref == 'refs/heads/main' # Deploy only from main branch
-        uses: actions/configure-pages@v5
-
-      - name: Upload artifact for GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: './docs/_build/html/'
-
       - name: Deploy to GitHub Pages
-        if: github.ref == 'refs/heads/main'
-        id: deployment
-        uses: actions/deploy-pages@v4
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build/html
+          publish_branch: gh-pages


### PR DESCRIPTION
This change in the workflow will build docs and send them to a separate gh-pages branch for the website, bypassing merge protections for main