### PR TITLE
Add short reads

### DIFF
--- a/src/finaletoolkit/cli/main_cli.py
+++ b/src/finaletoolkit/cli/main_cli.py
@@ -232,6 +232,12 @@ def main_cli_parser():
         '(mean, median, st. dev, min, max) over the intervals specified'
         ' in the interval file.')
     cli_frag_length_intervals.add_argument(
+        '-s',
+        '--short-reads',
+        default=150,
+        type=int,
+        help='Threshold for short read fraction. Default is 150.')
+    cli_frag_length_intervals.add_argument(
         '-q',
         '--quality-threshold',
         default=30,

--- a/src/finaletoolkit/cli/main_cli.py
+++ b/src/finaletoolkit/cli/main_cli.py
@@ -169,9 +169,24 @@ def main_cli_parser():
         help='A .TSV file containing containing fragment lengths binned'
         ' according to the specified bin size.')
     cli_frag_length_bins.add_argument(
+        '-stats',
+        '--summary-stats',
+        action="store_true",
+        help='Include summary statistics at the bottom of the output tsv as '
+        'comment lines (e.g. #max: 100)',
+    )
+    cli_frag_length_bins.add_argument(
+        '-sf',
+        '--short-fraction',
+        default=None,
+        type=int,
+        help='When specified, a short fraction is included in summary '
+        'statistics.',
+    )
+    cli_frag_length_bins.add_argument(
         '--histogram-path',
         default=None,
-        help='Path to store histogram.',
+        help='Path to store histogram if specified.',
     )
     cli_frag_length_bins.add_argument(
         '-q',

--- a/src/finaletoolkit/frag/_multi_wps.py
+++ b/src/finaletoolkit/frag/_multi_wps.py
@@ -211,9 +211,16 @@ def multi_wps(
         stops.append(prev_stop)
     finally:
         if site_bed != '-':
-            bed.close()  
-    
-    chrom_sizes_intervals = [chrom_sizes_dict[contig] for contig in contigs]
+            bed.close()
+
+    try:
+        chrom_sizes_intervals = [chrom_sizes_dict[contig] for contig in contigs]
+    except KeyError:
+        raise ValueError(
+            f"Chrom {contig} from {site_bed} is not present in {input_file} or "
+            "chrom.sizes file if applicable). Please ensure that all files use "
+            "the same reference genome and chromosome naming conventions."
+        )
 
     count = len(contigs)
 


### PR DESCRIPTION
# Changed
- add `short_reads` and `--short-reads` options to python API and CLI respectively for interval frag length to allow for customization of short read length
- fixed output for short read column to be a fraction, not total count.
- Add `--summary-stats` and `--short-fraction` options to `frag-length-bins`. When `--summary-stats` flag is specified, some helpful statistics are appended to the end of the output file (if also specified) as comment lines. When `--short-fraction={n}` is specified, a short fraction of `n` is calculated and included in summary stats and/or histogram.
# Fixed
- Add error checking for intervals in wps
- Add error handling to breakpoint motifs