### PR TITLE
166 crash in wps command valueerror negative dimensions are not allowed

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,67 @@ The format is based on
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Python 3.13 added to GitHub Actions CI test matrix.
+- Snakemake workflow section added to README.
+
+### Fixed
+- `multi_wps` no longer crashes with `ValueError: negative dimensions are not
+  allowed` when BED intervals produce degenerate windows (e.g. when expanded
+  intervals exceed chromosome boundaries or when closely spaced TSS sites
+  trigger overlap-trimming that inverts `start`/`stop`).
+  - `stop` is now clamped to chromosome size when computing expanded windows.
+  - Degenerate intervals (`stop <= start`) produced by overlap-trimming are
+    silently skipped instead of being forwarded to worker processes.
+  - `wps` now checks for `stop <= start` at function entry, emits a
+    `UserWarning`, and returns an empty result rather than crashing.
+
+### Changed
+- `low_quality_read_pairs` in `utils` now also checks the `MQ` (mate mapping
+  quality) BAM tag and marks a read pair as low quality if the mate's mapping
+  quality falls below `min_mapq`.
+
+## [0.11.0] - 2025-09-05
+
+### Added
+- New `breakpoint-motifs` and `interval-breakpoint-motifs` CLI subcommands and
+  corresponding Python API (`finaletoolkit.frag.breakpoint_motifs`) for
+  computing breakpoint motif frequencies from cfDNA fragments.
+- `--summary-stats` flag for `frag-length-bins`: appends summary statistics
+  (mean, median, short fraction, etc.) as comment lines to the output file.
+- `--short-fraction` option for `frag-length-bins` to specify the length
+  threshold used when computing the short-fragment fraction.
+- `--short-reads` option for `frag-length-intervals` to customize the short
+  read length threshold (previously hard-coded).
+- Automated documentation build workflow (`.github/workflows/build-docs.yml`).
+- `frag.gz` (FinaleDB format) accepted wherever `bed.gz` fragment files were
+  previously accepted in `frag_generator`.
+
+### Changed
+- `chrom_sizes` is now a **required** argument for Python API functions and CLI
+  commands that previously accepted it as optional (affects `multi_wps`,
+  `cleavage_profile`, and related subcommands).
+- DELFI GC-correction flag logic made more intuitive: passing `-G` /
+  `--no-gc-correct` now unambiguously disables GC correction.
+- Deprecated DELFI subcommands now appear in verbose logs.
+
+### Fixed
+- `cleavage-profile` now correctly reads chromosome sizes when a `chrom_sizes`
+  file is provided (PR #158).
+- `multi_wps` now issues a `UserWarning` and skips BED intervals whose
+  chromosome is absent from `chrom_sizes`, rather than raising a `KeyError`.
+- Additional error checking for intervals passed to `wps` (e.g. `start >
+  stop` now raises a descriptive error).
+- `end_motifs` no longer duplicates the last interval when parallelizing over
+  chromosomes.
+- `breakpoint_motifs` parallelization race condition fixed.
+- `delfi` and `adjust-wps` now handle chromosomes without centromere
+  annotations (e.g. chrM, chrX, chrY) without crashing (PR #156, @skchronicles).
+- `agg_bigwig` no longer crashes when a BigWig file has no entries over a
+  given genomic range (PR #156, @skchronicles).
+
 ## [0.10.7] - 2025-1-22
 
 ### Added

--- a/src/finaletoolkit/frag/_frag_length.py
+++ b/src/finaletoolkit/frag/_frag_length.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import time
+import warnings
 from typing import Union
 from sys import stdout, stderr
 from multiprocessing import Pool
@@ -345,12 +346,20 @@ def frag_length_bins(
     
     frag_len_dict = _distribution_from_gen(frag_gen)
 
+    total_count = sum(frag_len_dict.values())
+    if total_count == 0:
+        warnings.warn(
+            "No fragments found in the specified region. Returning empty result.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return np.array([]), np.array([])
+
     mean = (sum(value * count for value, count in frag_len_dict.items())
-            / sum(frag_len_dict.values()))
+            / total_count)
     variance = (sum(count * ((value - mean) ** 2)
                     for value, count in frag_len_dict.items())
-                / sum(frag_len_dict.values()))
-    total_count = sum(frag_len_dict.values())
+                / total_count)
 
     # get statistics
     stats = []

--- a/src/finaletoolkit/frag/_multi_wps.py
+++ b/src/finaletoolkit/frag/_multi_wps.py
@@ -191,24 +191,26 @@ def multi_wps(
             midpoint = (int(contents[1]) + int(contents[2])) // 2
 
             start = max(0, midpoint + int(left_of_site))
-            stop = midpoint + int(right_of_site)
+            stop = min(midpoint + int(right_of_site), chrom_sizes_dict[contig])
 
             # cut off part of previous interval if overlap
             if contig == prev_contig and start < prev_stop:
                 prev_stop = start
 
             if prev_contig is not None:
-                contigs.append(prev_contig)
-                starts.append(prev_start)
-                stops.append(prev_stop)
+                if prev_stop > prev_start:  # skip degenerate intervals
+                    contigs.append(prev_contig)
+                    starts.append(prev_start)
+                    stops.append(prev_stop)
 
             prev_contig = contig
             prev_start = start
             prev_stop = stop
         # appending last interval
-        contigs.append(prev_contig)
-        starts.append(prev_start)
-        stops.append(prev_stop)
+        if prev_stop > prev_start:  # skip degenerate intervals
+            contigs.append(prev_contig)
+            starts.append(prev_start)
+            stops.append(prev_stop)
     finally:
         if site_bed != '-':
             bed.close()

--- a/src/finaletoolkit/frag/_wps.py
+++ b/src/finaletoolkit/frag/_wps.py
@@ -122,6 +122,22 @@ def wps(input_file: Union[str, pysam.AlignmentFile],
     start = int(start)
     stop = int(stop)
 
+    if stop <= start:
+        warnings.warn(
+            f"[wps] {chrom}:{start}-{stop} is a degenerate interval "
+            "(stop <= start); skipping.",
+            UserWarning,
+            stacklevel=2,
+        )
+        return np.zeros(
+            0,
+            dtype=[
+                ('contig', 'U16'),
+                ('start', 'i8'),
+                ('wps', 'i8'),
+            ]
+        )
+
     # set minimum and maximum values for fragments. These extend farther
     # than needed
     minimum = max(round(start - max_length), 0)


### PR DESCRIPTION
- fixed issue by clamping `stop` to chromosome size in `multi_wps`, skipping degenerate intervals after trimming overlaps, and adding check to `wps` for `stop <= start`.
- Updated changelog
- Include python 3.13 to Github CI testing