### PR TITLE
perf(cleavage-profile): replace O(frags*positions) matrix with diff-array

### DIFF
--- a/src/finaletoolkit/frag/_cleavage_profile.py
+++ b/src/finaletoolkit/frag/_cleavage_profile.py
@@ -30,6 +30,66 @@ __all__ = ["cleavage_profile", "multi_cleavage_profile"]
 _CLEAVAGE_DTYPE = [("contig", "U16"), ("pos", "i8"), ("proportion", "f8")]
 
 
+def _coverage_and_ends(
+    frag_starts: np.ndarray,
+    frag_stops: np.ndarray,
+    frag_strands: np.ndarray,
+    adj_start: int,
+    adj_stop: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per-position fragment depth and fragment-end counts over an interval.
+
+    Equivalent to broadcasting each fragment against each position (an
+    ``(n_fragments, n_positions)`` boolean matrix) but computed with a
+    coverage difference array instead, so memory is ``O(n_positions)``
+    rather than ``O(n_fragments * n_positions)``.
+
+    Parameters
+    ----------
+    frag_starts, frag_stops : numpy.ndarray
+        Fragment start/stop coordinates (half-open, ``[start, stop)``).
+    frag_strands : numpy.ndarray
+        Boolean array, ``True`` for ``+`` strand fragments.
+    adj_start, adj_stop : int
+        Half-open interval of positions to compute over.
+
+    Returns
+    -------
+    depth : numpy.ndarray
+        Number of fragments covering each position, shape
+        ``(adj_stop - adj_start,)``.
+    ends : numpy.ndarray
+        Number of fragment ends (start of + strand fragments, stop of -
+        strand fragments) at each position, same shape as ``depth``.
+    """
+    n = adj_stop - adj_start
+
+    raw_start_idx = frag_starts - adj_start
+    raw_stop_idx = frag_stops - adj_start
+
+    # Depth via a coverage difference array: +1 where a fragment starts,
+    # -1 where it stops, then a cumulative sum. Indices are clipped to
+    # [0, n] since fragments may extend beyond the interval (frag_array is
+    # called with intersect_policy="any").
+    depth_diff = np.zeros(n + 1, dtype=np.int64)
+    np.add.at(depth_diff, np.clip(raw_start_idx, 0, n), 1)
+    np.add.at(depth_diff, np.clip(raw_stop_idx, 0, n), -1)
+    depth = np.cumsum(depth_diff[:-1])
+
+    # Fragment ends: forward fragments end at their start (+ strand),
+    # reverse fragments end at their stop (- strand). Unlike depth, an
+    # end that falls outside the interval must be dropped rather than
+    # clipped to the boundary.
+    forward_mask = frag_strands
+    fwd_idx = raw_start_idx[forward_mask]
+    fwd_idx = fwd_idx[(fwd_idx >= 0) & (fwd_idx < n)]
+    rev_idx = raw_stop_idx[~forward_mask]
+    rev_idx = rev_idx[(rev_idx >= 0) & (rev_idx < n)]
+    ends = np.bincount(fwd_idx, minlength=n) + np.bincount(rev_idx, minlength=n)
+
+    return depth, ends
+
+
 def cleavage_profile(
     input_file: FragFile,
     chrom_size: int,
@@ -143,25 +203,9 @@ def cleavage_profile(
     )
 
     positions = np.arange(adj_start, adj_stop)
-
-    # Depth: number of fragments covering each position.
-    fragwise_overlaps = np.logical_and(
-        np.greater_equal(positions[np.newaxis], frags["start"][:, np.newaxis]),
-        np.less(positions[np.newaxis], frags["stop"][:, np.newaxis]),
+    depth, ends = _coverage_and_ends(
+        frags["start"], frags["stop"], frags["strand"], adj_start, adj_stop
     )
-    depth = np.sum(fragwise_overlaps, axis=0)
-
-    # Fragment ends: forward fragments end at their start (+ strand),
-    # reverse fragments end at their stop (- strand).
-    forward_ends = np.logical_and(
-        np.equal(positions[np.newaxis], frags["start"][:, np.newaxis]),
-        frags["strand"][:, np.newaxis],
-    )
-    reverse_ends = np.logical_and(
-        np.equal(positions[np.newaxis], frags["stop"][:, np.newaxis]),
-        np.logical_not(frags["strand"][:, np.newaxis]),
-    )
-    ends = np.sum(np.logical_or(forward_ends, reverse_ends), axis=0)
 
     proportions = np.zeros_like(depth, dtype=np.float64)
     non_zero_mask = depth != 0

--- a/tests/test_cleavage_profile.py
+++ b/tests/test_cleavage_profile.py
@@ -11,6 +11,7 @@ import pytest
 import numpy as np
 
 from finaletoolkit.frag import cleavage_profile
+from finaletoolkit.frag._cleavage_profile import _coverage_and_ends
 
 class TestIntervalCleavageProfile:
     def test_cpg_34443200(self, request):
@@ -22,4 +23,119 @@ class TestIntervalCleavageProfile:
         assert np.all(results['contig'] == '12')
         assert np.all(results['pos'] == np.arange(34443195, 34443206)), str(results)
         assert np.all(results['proportion'] == np.zeros(11, np.int64)), str(results)
-        
+
+
+def _brute_force_coverage_and_ends(starts, stops, strands, adj_start, adj_stop):
+    """Reference implementation: the original (n_fragments, n_positions)
+    broadcast-matrix algorithm that _coverage_and_ends replaces."""
+    positions = np.arange(adj_start, adj_stop)
+
+    fragwise_overlaps = np.logical_and(
+        np.greater_equal(positions[np.newaxis], starts[:, np.newaxis]),
+        np.less(positions[np.newaxis], stops[:, np.newaxis]),
+    )
+    depth = np.sum(fragwise_overlaps, axis=0)
+
+    forward_ends = np.logical_and(
+        np.equal(positions[np.newaxis], starts[:, np.newaxis]),
+        strands[:, np.newaxis],
+    )
+    reverse_ends = np.logical_and(
+        np.equal(positions[np.newaxis], stops[:, np.newaxis]),
+        np.logical_not(strands[:, np.newaxis]),
+    )
+    ends = np.sum(np.logical_or(forward_ends, reverse_ends), axis=0)
+
+    return depth, ends
+
+
+class TestCoverageAndEndsEquivalence:
+    """_coverage_and_ends (diff-array) must match the brute-force
+    broadcast-matrix algorithm it replaces, on both random fragment sets
+    and boundary edge cases."""
+
+    @pytest.mark.parametrize("seed", range(25))
+    def test_random_fragments(self, seed):
+        rng = np.random.default_rng(seed)
+        adj_start, adj_stop = 1000, 1200
+        n_frags = rng.integers(0, 200)
+
+        # Fragments may start/stop outside the window (frag_array is
+        # called with intersect_policy="any"), so sample from a padded
+        # range and keep only those that actually overlap the window.
+        starts = rng.integers(adj_start - 50, adj_stop + 50, size=n_frags)
+        lengths = rng.integers(1, 300, size=n_frags)
+        stops = starts + lengths
+        strands = rng.integers(0, 2, size=n_frags).astype(bool)
+
+        overlap_mask = (starts < adj_stop) & (stops > adj_start)
+        starts, stops, strands = (
+            starts[overlap_mask],
+            stops[overlap_mask],
+            strands[overlap_mask],
+        )
+
+        expected_depth, expected_ends = _brute_force_coverage_and_ends(
+            starts, stops, strands, adj_start, adj_stop
+        )
+        depth, ends = _coverage_and_ends(
+            starts, stops, strands, adj_start, adj_stop
+        )
+
+        np.testing.assert_array_equal(depth, expected_depth)
+        np.testing.assert_array_equal(ends, expected_ends)
+
+    def test_empty_fragments(self):
+        starts = np.array([], dtype=np.int64)
+        stops = np.array([], dtype=np.int64)
+        strands = np.array([], dtype=bool)
+
+        depth, ends = _coverage_and_ends(starts, stops, strands, 100, 150)
+
+        assert np.all(depth == 0)
+        assert np.all(ends == 0)
+        assert depth.shape == (50,)
+        assert ends.shape == (50,)
+
+    def test_degenerate_interval(self):
+        starts = np.array([100, 105], dtype=np.int64)
+        stops = np.array([120, 130], dtype=np.int64)
+        strands = np.array([True, False], dtype=bool)
+
+        depth, ends = _coverage_and_ends(starts, stops, strands, 100, 100)
+
+        assert depth.shape == (0,)
+        assert ends.shape == (0,)
+
+    def test_fragment_spans_entire_window(self):
+        # A fragment starting before and ending after the window should
+        # contribute to depth everywhere but not to ends anywhere.
+        starts = np.array([50], dtype=np.int64)
+        stops = np.array([200], dtype=np.int64)
+        strands = np.array([True], dtype=bool)
+
+        depth, ends = _coverage_and_ends(starts, stops, strands, 100, 150)
+
+        assert np.all(depth == 1)
+        assert np.all(ends == 0)
+
+    def test_ends_exactly_at_window_boundaries(self):
+        # Window is [100, 150). frag 0 (+): starts exactly at adj_start
+        # (100) -> should register. frag 1 (-): stops exactly at adj_stop
+        # (150), one past the last position (149) -> half-open, should
+        # NOT register. frag 2 (-): stops at 149, the last position in
+        # the window -> should register.
+        starts = np.array([100, 90, 90], dtype=np.int64)
+        stops = np.array([200, 150, 149], dtype=np.int64)
+        strands = np.array([True, False, False], dtype=bool)
+
+        depth, ends = _coverage_and_ends(starts, stops, strands, 100, 150)
+
+        expected_depth, expected_ends = _brute_force_coverage_and_ends(
+            starts, stops, strands, 100, 150
+        )
+        np.testing.assert_array_equal(depth, expected_depth)
+        np.testing.assert_array_equal(ends, expected_ends)
+        assert ends[0] == 1  # start of frag 0 at position 100
+        assert ends[-1] == 1  # stop of frag 2 at position 149
+


### PR DESCRIPTION
## Summary
- `cleavage_profile` built an `(n_fragments, n_positions)` boolean matrix via numpy broadcasting to compute per-position depth and fragment-end counts. Memory scales as O(fragments x positions), which OOMs on large intervals — a real HPC job hit a 717 GiB allocation attempt for a 118k-fragment x 6.5M-position interval (bins from a 500kb-tiled BED file got merged into one large interval by `_read_intervals`, since padding by `left`/`right` causes adjacent tiled bins to overlap and cascade-merge).
- Replaced the broadcast matrix with `_coverage_and_ends`, a sweep-line/diff-array algorithm: a coverage difference array + cumsum for depth, and `bincount` for fragment-end counts. Memory is now O(positions), independent of fragment count.
- No change to `multi_cleavage_profile`, `wps`, or the interval-merging logic in `_read_intervals` — this PR is scoped to the one hot allocation. Happy to follow up on the merge-cascade behavior in `_read_intervals` separately if useful.

## Verification
- Added `TestCoverageAndEndsEquivalence` in `tests/test_cleavage_profile.py`: 25 random-fuzz seeds plus edge cases (empty fragments, degenerate interval, fragment spanning the whole window, ends exactly at window boundaries), all checked against a brute-force reference (the original algorithm) kept inline in the test file.
- Full existing suite passes (125 passed, 11 skipped for missing `samtools`).
- Ran `cleavage_profile` end-to-end on two real BAM fixtures across 6 intervals (old code from a `main` worktree vs. this branch) — outputs were bit-for-bit identical (`np.array_equal` on contig/pos/proportion arrays).
- Ran the new implementation alone on a 6 Mb / 42,931-fragment interval (matching the scale of the original OOM report): completed in ~2s, peak RSS ~1.2 GB. The old algorithm's matrix for that case alone would need ~32 GB — capped the old-vs-new real-BAM comparison at 1.5M positions (~1.1 GB matrix) to stay within a Macbook's 16 GB RAM.

## Test plan
- [x] `pytest tests/test_cleavage_profile.py -v`
- [x] `pytest tests/ -q` (full suite)
- [x] Manual old-vs-new equivalence check on real BAM fixtures
