### PR TITLE
Add optional Miller-Madow correction to rMDS

### DIFF
--- a/src/finaletoolkit/cli/commands/__init__.py
+++ b/src/finaletoolkit/cli/commands/__init__.py
@@ -618,6 +618,15 @@ def mds(**params):
     type=int,
     help="Number of header rows to ignore.",
 )
+@click.option(
+    "--miller-madow",
+    "miller_madow",
+    is_flag=True,
+    default=False,
+    help="Apply the Miller-Madow bias correction to each region's rMDS. "
+    "Counteracts the downward bias of the plug-in entropy estimator in "
+    "regions with few fragments.",
+)
 def regional_mds(**params):
     """Regional Motif Diversity Score (rMDS) for each region (Bandaru et al. 2026).
 

--- a/src/finaletoolkit/frag/_breakpoint_motifs.py
+++ b/src/finaletoolkit/frag/_breakpoint_motifs.py
@@ -386,8 +386,12 @@ def _cli_mds(file_path: str, sep: str = "\t", header: int = 0) -> None:
 
 
 def _cli_regional_mds(
-    file_path: str, file_out: str, sep: str = ",", header: int = 0
+    file_path: str,
+    file_out: str,
+    sep: str = ",",
+    header: int = 0,
+    miller_madow: bool = False,
 ) -> None:
     """CLI: write the regional MDS (rMDS) of each region to ``file_out``."""
     motifs = BreakpointMotifsIntervals.from_file(file_path, 30, sep, header)
-    motifs.mds_bed(file_out)
+    motifs.mds_bed(file_out, miller_madow=miller_madow)

--- a/src/finaletoolkit/frag/_end_motifs.py
+++ b/src/finaletoolkit/frag/_end_motifs.py
@@ -391,8 +391,12 @@ def _cli_mds(file_path: str, sep: str = "\t", header: int = 0) -> None:
 
 
 def _cli_regional_mds(
-    file_path: str, file_out: str, sep: str = ",", header: int = 0
+    file_path: str,
+    file_out: str,
+    sep: str = ",",
+    header: int = 0,
+    miller_madow: bool = False,
 ) -> None:
     """CLI: write the regional MDS (rMDS) of each region to ``file_out``."""
     motifs = EndMotifsIntervals.from_file(file_path, 30, sep, header)
-    motifs.mds_bed(file_out)
+    motifs.mds_bed(file_out, miller_madow=miller_madow)

--- a/src/finaletoolkit/frag/_motif_common.py
+++ b/src/finaletoolkit/frag/_motif_common.py
@@ -35,24 +35,63 @@ _WINDOW_SIZE = 1_000_000
 __all__ = ["FPROFILE_PATH", "MIN_QUALITY"]
 
 
-def _normalized_shannon_mds(counts: np.ndarray, k: int) -> float:
+def _normalized_shannon_mds(
+    counts: np.ndarray,
+    k: int,
+    miller_madow: bool = False,
+    n: float | None = None,
+) -> float:
     """Normalized-Shannon-entropy motif diversity score (Jiang et al., 2020).
 
     Generalized to any ``k``.  Zero-frequency motifs contribute nothing.
+
+    Parameters
+    ----------
+    counts : numpy.ndarray
+        Motif *frequencies* (normalized to sum to 1).
+    k : int
+        K-mer length; the entropy is normalized by ``log(4**k)``.
+    miller_madow : bool, optional
+        Apply the Miller-Madow bias correction (default ``False``).  The
+        plug-in entropy estimator is biased downward by roughly
+        ``(m - 1) / (2N)`` nats, where ``m`` is the number of occupied bins
+        and ``N`` the number of observations; Miller-Madow adds that term
+        back.  ``m`` is taken to be the number of motifs with non-zero
+        frequency.
+    n : float, optional
+        Number of observations (fragment ends) the frequencies were
+        estimated from.  Required when ``miller_madow`` is ``True``.
+
+    Returns
+    -------
+    float
+        The motif diversity score, or ``nan`` if the frequencies are
+        undefined.  Note that for very small ``n`` the corrected score can
+        exceed 1; it is deliberately not clipped so that the estimator's
+        behavior stays visible.
     """
     num_kmers = 4**k
     freq = np.asarray(counts, dtype=np.float64)
-    return float(
-        -np.sum(
-            freq
-            * np.log(
-                freq,
-                out=np.zeros_like(freq, dtype=np.float64),
-                where=(freq != 0),
-            )
-            / np.log(num_kmers)
+    entropy = -np.sum(
+        freq
+        * np.log(
+            freq,
+            out=np.zeros_like(freq, dtype=np.float64),
+            where=(freq != 0),
         )
     )
+
+    if miller_madow:
+        if n is None:
+            raise ValueError(
+                "n is required when miller_madow is True."
+            )
+        if not n > 0:
+            return float("nan")
+        occupied = int(np.count_nonzero(np.nan_to_num(freq)))
+        entropy = entropy + (occupied - 1) / (2 * n)
+
+    return float(entropy / np.log(num_kmers))
 
 
 def resolve_motif_aliases(
@@ -235,13 +274,35 @@ class _MotifsIntervals:
         intervals: list[tuple[tuple, dict]],
         k: int,
         quality_threshold: int = MIN_QUALITY,
+        total_counts: list[float] | None = None,
     ) -> None:
+        """
+        Parameters
+        ----------
+        intervals : list of tuple
+            ``((contig, start, stop, name), {kmer: value})`` pairs.
+        k : int
+            K-mer length.
+        quality_threshold : int, optional
+            Stored on the instance.
+        total_counts : list of float, optional
+            Per-interval observation count ``N``, aligned with ``intervals``.
+            Only needed when the stored values are normalized frequencies
+            rather than raw counts, which is the case when reading back a
+            table written with ``calc_freq=True``.  When omitted, ``N`` is
+            taken to be the sum of each interval's values.
+        """
         self.intervals = intervals
         self.k = k
         self.quality_threshold = quality_threshold
+        self.total_counts = total_counts
         if not all(len(freqs) == 4**k for _, freqs in intervals):
             raise ValueError(
                 "bins contains results for kmer with length not equal to k."
+            )
+        if total_counts is not None and len(total_counts) != len(intervals):
+            raise ValueError(
+                "total_counts must have one entry per interval."
             )
 
     def __iter__(self) -> Iterator:
@@ -283,6 +344,7 @@ class _MotifsIntervals:
                 file.readline()
 
             intervals = []
+            total_counts = []
             lines = file.readlines()
             _, _, _, _, _, *kmers = lines[0].split(sep)
             k = round(np.log(len(kmers)) / np.log(4))
@@ -294,10 +356,13 @@ class _MotifsIntervals:
                 float_freqs = [float(freq) for freq in freqs]
                 dict_freqs = dict(zip(kmers, float_freqs))
                 intervals.append(((contig, start, stop, name), dict_freqs))
+                # Retained so the Miller-Madow correction knows N even when
+                # the table stores frequencies rather than raw counts.
+                total_counts.append(float(count))
         finally:
             if is_file and file is not None:
                 file.close()
-        return cls(intervals, k, quality_threshold)
+        return cls(intervals, k, quality_threshold, total_counts)
 
     def freq(self, kmer: str) -> dict[tuple[str, int, int], float]:
         """Map each interval to its frequency for a single k-mer."""
@@ -305,22 +370,45 @@ class _MotifsIntervals:
             (*interval, freq[kmer]) for interval, freq in self.intervals
         )
 
-    def motif_diversity_score(self) -> list[tuple[tuple, float]]:
-        """Regional motif diversity score (rMDS) for each region (any ``k``)."""
+    def motif_diversity_score(
+        self, miller_madow: bool = False
+    ) -> list[tuple[tuple, float]]:
+        """Regional motif diversity score (rMDS) for each region (any ``k``).
+
+        Parameters
+        ----------
+        miller_madow : bool, optional
+            Apply the Miller-Madow bias correction (default ``False``).  The
+            plug-in entropy estimator underestimates diversity in regions with
+            few fragments; the correction adds back ``(m - 1) / (2N)`` nats,
+            where ``m`` is the number of observed motifs and ``N`` the
+            region's fragment-end count.  Because the correction shrinks as
+            ``N`` grows, it mostly affects sparse regions.
+        """
         mds = []
-        for interval, kmers in self.intervals:
+        for index, (interval, kmers) in enumerate(self.intervals):
             counts = np.array(list(kmers.values()))
             total = np.sum(counts)
-            try:
-                region_mds = _normalized_shannon_mds(counts / total, self.k)
-            except RuntimeWarning:
-                region_mds = np.nan
+            n = (
+                self.total_counts[index]
+                if self.total_counts is not None
+                else total
+            )
+            with np.errstate(invalid="ignore", divide="ignore"):
+                region_mds = _normalized_shannon_mds(
+                    counts / total, self.k, miller_madow, n
+                )
             mds.append((interval, region_mds))
         return mds
 
-    def mds_bed(self, output_file: str | Path, sep: str = "\t") -> None:
+    def mds_bed(
+        self,
+        output_file: str | Path,
+        sep: str = "\t",
+        miller_madow: bool = False,
+    ) -> None:
         """Write the regional MDS (rMDS) of each region to a BED/bedgraph file."""
-        mds = self.motif_diversity_score()
+        mds = self.motif_diversity_score(miller_madow)
         with open(output_file, "w") as out:
             for interval, region_mds in mds:
                 contig, start, stop, name = interval

--- a/tests/test_end_motifs.py
+++ b/tests/test_end_motifs.py
@@ -7,9 +7,11 @@ import os
 import filecmp
 import difflib
 
+import numpy as np
 import pytest
 
 from finaletoolkit.frag import end_motifs, EndMotifFreqs, EndMotifsIntervals, interval_end_motifs
+from finaletoolkit.utils import gen_kmers
 
 class TestGenomewideEndMotifs:
     def test_end_motifs(self, request):
@@ -172,5 +174,74 @@ class TestCLIRegionalMDS:
         os.system(f'finaletoolkit regional-mds {src_tsv} {dest}')
         with open(dest) as file:
             line = file.readline()
-            chrom, start, stop, name, mds = line.split() 
+            chrom, start, stop, name, mds = line.split()
         assert float(mds) == pytest.approx(0.5844622669209985, 0.01)
+
+    def test_regional_mds_miller_madow(self, request, tmp_path):
+        """--miller-madow raises rMDS by the analytic (m-1)/(2N) term."""
+        src_tsv = request.path.parent / 'data' / 'end_motifs' / 'end_motifs_intervals_dif.tsv'
+        dest = tmp_path / "regional_mds_mm.tsv"
+        os.system(f'finaletoolkit regional-mds {src_tsv} {dest} --miller-madow')
+        with open(dest) as file:
+            chrom, start, stop, name, mds = file.readline().split()
+        # The region holds N=34 fragment ends across m=27 observed 4-mers, so
+        # the correction is (27 - 1) / (2 * 34) / log(4**4).
+        expected = 0.5844622669209985 + 26 / 68 / np.log(256)
+        assert float(mds) == pytest.approx(expected, 0.01)
+
+
+class TestRegionalMDSMillerMadow:
+    """Miller-Madow bias correction on the rMDS API."""
+
+    @staticmethod
+    def _intervals(request):
+        src_tsv = (
+            request.path.parent / 'data' / 'end_motifs'
+            / 'end_motifs_intervals_dif.tsv'
+        )
+        return EndMotifsIntervals.from_file(str(src_tsv), 30, '\t', 0)
+
+    def test_off_by_default(self, request):
+        motifs = self._intervals(request)
+        assert (
+            motifs.motif_diversity_score()
+            == motifs.motif_diversity_score(miller_madow=False)
+        )
+
+    def test_correction_matches_formula(self, request):
+        motifs = self._intervals(request)
+        (_, plain), = motifs.motif_diversity_score()
+        (_, corrected), = motifs.motif_diversity_score(miller_madow=True)
+
+        _, kmers = motifs.intervals[0]
+        counts = np.array(list(kmers.values()))
+        n = counts.sum()
+        occupied = int((counts > 0).sum())
+
+        assert corrected > plain
+        assert corrected - plain == pytest.approx(
+            (occupied - 1) / (2 * n) / np.log(4 ** motifs.k)
+        )
+
+    def test_frequency_table_round_trip(self, request, tmp_path):
+        """N survives a to_tsv/from_file round trip through frequencies.
+
+        ``to_tsv(calc_freq=True)`` normalizes the per-motif values away, so the
+        correction has to read N from the retained ``count`` column rather than
+        summing the row (which would give 1).
+        """
+        motifs = self._intervals(request)
+        dest = tmp_path / "freqs.tsv"
+        motifs.to_tsv(dest, calc_freq=True)
+        reloaded = EndMotifsIntervals.from_file(str(dest), 30, '\t', 0)
+
+        (_, from_counts), = motifs.motif_diversity_score(miller_madow=True)
+        (_, from_freqs), = reloaded.motif_diversity_score(miller_madow=True)
+        assert from_freqs == pytest.approx(from_counts)
+
+    def test_empty_region_is_nan(self):
+        """A region with no fragments yields NaN rather than dividing by zero."""
+        kmers = dict.fromkeys(gen_kmers(4, "ACGT"), 0.0)
+        motifs = EndMotifsIntervals([(("12", 0, 100, "."), kmers)], 4, 30)
+        (_, score), = motifs.motif_diversity_score(miller_madow=True)
+        assert np.isnan(score)


### PR DESCRIPTION
## Summary

Adds an **opt-in** Miller-Madow bias correction to the regional Motif Diversity Score (rMDS).

The plug-in Shannon entropy estimator underlying rMDS is biased downward when a region contains few fragments, which makes rMDS values from regions of differing depth hard to compare. The correction adds `(m - 1) / (2N)` nats back to the entropy before normalizing by `log(4^k)`, where `m` is the number of distinct motifs observed in the region and `N` is the region's fragment-end count.

**Off by default — existing rMDS output is unchanged.**

## Interface

```python
intervals.motif_diversity_score(miller_madow=True)
intervals.mds_bed(path, miller_madow=True)
```

```console
$ finaletoolkit regional-mds intervals.tsv rmds.bed --miller-madow
```

Both `EndMotifsIntervals` and `BreakpointMotifsIntervals` are covered — the implementation lives on the shared `_MotifsIntervals` base, so breakpoint motifs come along for free.

## Design notes

**`m` is the number of *observed* (non-zero) motifs**, not the full `4^k` support. This is standard Miller-Madow and adapts to sparse regions; using `4^k` would over-correct low-coverage windows.

**Where `N` comes from.** `from_file` previously parsed the interval table's `count` column and discarded it; it is now retained as `total_counts`. This matters: `to_tsv(calc_freq=True)` — the default — normalizes the per-motif values away, so summing a row from such a table gives 1 and a meaningless correction. The `count` column is the only surviving source of `N`. A counts table and its frequency round-trip are verified to produce identical corrected scores.

**Whole-sample `mds` is deliberately not corrected.** `EndMotifFreqs` stores only normalized frequencies and its TSV has no count column, so `N` is not recoverable there. Whole-sample MDS is also computed from enough fragments that the correction would be negligible. Adding it later would mean an explicit `n` argument rather than a format change.

**Scores are not clipped.** At very small `N` the corrected value can exceed 1; this is left visible rather than capped.

## Drive-by

Replaces a `try/except RuntimeWarning` around the rMDS division that could never fire (numpy warnings are not exceptions unless `simplefilter("error")` is set) with explicit `np.errstate` suppression. Empty regions still yield `NaN`, now deliberately.

## Verification

On the existing fixture (`N=34` ends across 27 distinct 4-mers):

| | rMDS |
|---|---|
| default | 0.584462 |
| `--miller-madow` | 0.653415 |

matching the hand-computed `0.5844623 + 26/68/ln(256)`.

Default output is unchanged to 15 significant figures; the last 2 ULP shift (`…209985` → `…209983`) because normalization now happens once at the end rather than inside the sum.

Full suite: **130 passed, 11 skipped** — same skips as baseline (CRAM tests, `samtools`-gated). Four new tests cover the formula, off-by-default, the frequency round-trip, and empty regions.

## Not included

No version bump — this is the functional change only. Documentation and CHANGELOG updates are held back for a separate PR.