### PR TITLE
build: derive package version from git tags via setuptools-scm

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags, needed by setuptools-scm to derive the version
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,35 @@
+name: Changelog check
+
+# Fails a PR that changes src/finaletoolkit/ without also updating
+# CHANGELOG.md. Add the "skip-changelog" label (test-only changes, internal
+# refactors with no user-visible effect, etc.) to bypass -- adding/removing
+# the label re-triggers this check via the labeled/unlabeled event types.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a CHANGELOG.md entry when src/finaletoolkit changes
+        run: |
+          changed=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}")
+          echo "Changed files:"
+          echo "$changed"
+          if echo "$changed" | grep -q '^src/finaletoolkit/'; then
+            if ! echo "$changed" | grep -qx 'CHANGELOG.md'; then
+              echo "::error::This PR changes src/finaletoolkit/ but doesn't update CHANGELOG.md. Add an entry under [Unreleased], or add the 'skip-changelog' label if this change has no user-visible effect (e.g. test-only or internal refactor)."
+              exit 1
+            fi
+          fi
+          echo "OK"

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0   # full history + tags, needed by setuptools-scm to derive the version
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v3
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history + tags, needed by setuptools-scm to derive the version
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -11,6 +11,21 @@ name: Upload Python Package
 on:
   release:
     types: [published]
+  # Also invocable directly as a reusable workflow (see release-tag.yml).
+  # release-tag.yml creates the GitHub Release itself using the default
+  # GITHUB_TOKEN, and GitHub does not let a GITHUB_TOKEN-authored event
+  # trigger further workflow runs (to prevent recursive triggers) -- so
+  # `release: published` alone would never fire in that path. Calling this
+  # workflow directly sidesteps that limitation.
+  workflow_call:
+    inputs:
+      version:
+        description: >-
+          Version being published, e.g. "1.1.0" (no leading "v"). Only
+          used for the PyPI project URL shown in the deployment;
+          publishing itself does not depend on it.
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -57,7 +72,7 @@ jobs:
       #
       # ALTERNATIVE: if your GitHub Release name is the PyPI project version string
       # ALTERNATIVE: exactly, uncomment the following line instead:
-      url: https://pypi.org/project/FinaleToolkit/${{ github.event.release.name }}
+      url: https://pypi.org/project/FinaleToolkit/${{ github.event.release.name || inputs.version }}
 
     steps:
       - name: Retrieve release distributions

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,54 @@
+name: Prepare release
+
+# Manually triggered: a maintainer decides it's time to cut a release and
+# supplies the version number. This workflow only prepares the CHANGELOG and
+# opens a PR for review -- nothing is tagged or published until that PR is
+# reviewed and merged (see release-tag.yml, triggered on merge).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version to release, e.g. "1.1.0" (no leading "v")'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update CHANGELOG.md
+        run: python3 scripts/prepare_release.py bump "${{ inputs.version }}"
+
+      - name: Open release PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          VERSION="${{ inputs.version }}"
+          BRANCH="release-v${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add CHANGELOG.md
+          git commit -m "Release v${VERSION}"
+          git push -u origin "$BRANCH"
+
+          # Idempotent: succeeds whether or not the label already exists.
+          gh label create release --color "0E8A16" \
+            --description "Merging tags the release and publishes to PyPI" \
+            --force
+
+          gh pr create \
+            --base main \
+            --title "Release v${VERSION}" \
+            --label release \
+            --body "Automated release preparation for v${VERSION}. Review the CHANGELOG.md changes, then merge to tag \`v${VERSION}\`, create the GitHub Release, and publish to PyPI (see .github/workflows/release-tag.yml)."

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,67 @@
+name: Tag and publish release
+
+# Fires when a "release-vX.Y.Z" PR (opened by release-prepare.yml) is merged:
+# tags the merge commit, creates a GitHub Release from the CHANGELOG section
+# for that version, then directly invokes python-publish.yml to build and
+# publish to PyPI.
+#
+# Directly invoking python-publish.yml (rather than relying on the
+# `release: published` event it also listens for) is deliberate: the GitHub
+# Release below is created with the default GITHUB_TOKEN, and GitHub does
+# not let a GITHUB_TOKEN-authored event trigger further workflow runs, to
+# prevent recursive triggers. `release: published` would never fire here.
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.base.ref }}
+
+      - name: Extract version and release notes
+        id: version
+        run: |
+          set -e
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release-v}"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          python3 scripts/prepare_release.py extract "$VERSION" > release_notes.md
+
+      - name: Create tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          VERSION="${{ steps.version.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "v${VERSION}"
+          git push origin "v${VERSION}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release_notes.md
+
+  publish:
+    needs: tag
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/python-publish.yml
+    with:
+      version: ${{ needs.tag.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__/
 *.pyc
 dist
 *.egg-info
+src/finaletoolkit/_version.py
 pip-wheel-metadata
 .vscode
 **/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+- The package version is now derived from git tags via `setuptools-scm`
+  instead of a hand-edited version string: `1.0.0` exactly on a tag,
+  `1.0.1.dev6` six commits past one. No action needed for normal installs;
+  contributors on an editable install (`pip install -e .`) should re-run
+  that command after pulling new commits if they want `finaletoolkit
+  --version` to reflect the latest commit.
+
 ### Fixed
 - `filter-file`/`filter_file` now accepts a `-r`/`--reference` (`reference_file`)
   option. Previously CRAM input to `filter-file` always failed with "CRAM

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,11 @@
 graft src/finaletoolkit
+
+# setuptools-scm's sdist file finder includes every git-tracked file by
+# default (docs/, .github/, and the large binary fixtures under
+# tests/data/), ballooning the sdist from ~100KB to tens of MB. Prune them
+# back out to restore the prior, intentional scope: package source plus the
+# test *.py files (auto-discovered by setuptools), without test data,
+# CI config, or doc sources.
+prune tests/data
+prune docs
+prune .github

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [Compatible File Formats](#compatible-file-formats)
   - [Using Fragment Files](#using-fragment-files)
   - [Snakemake Workflow](#snakemake-workflow)
+- [Contributing](#contributing)
 - [Contact](#contact)
 - [License](#license)
 
@@ -94,6 +95,12 @@ fragment files. Learn more about FinaleDB [here](http://finaledb.research.cchmc.
 
 Check out our
 [Snakemake workflow](https://github.com/epifluidlab/finaletoolkit_workflow)!
+
+## Contributing
+
+PRs that change `src/finaletoolkit/` should add a `CHANGELOG.md` entry under
+`[Unreleased]`. See [RELEASING.md](RELEASING.md) for that convention and for
+how releases are cut.
 
 ## Contact
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,72 @@
+# Releasing FinaleToolkit
+
+This describes the CI automation around `CHANGELOG.md` and cutting a release.
+The workflows referenced here live in `.github/workflows/`; the CHANGELOG
+helper script lives in `scripts/prepare_release.py`.
+
+## While working on a PR
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+If your PR changes anything under `src/finaletoolkit/`, add a bullet point
+under the `## [Unreleased]` heading at the top of the file, in the relevant
+`### Added` / `### Changed` / `### Fixed` / `### Removed` subsection (create
+the subsection if it doesn't exist yet). Write it for a user of the package,
+not as a commit-log summary -- what changed and why it matters to them.
+
+**[changelog-check.yml](.github/workflows/changelog-check.yml)** enforces
+this: a PR that touches `src/finaletoolkit/` without also touching
+`CHANGELOG.md` fails CI. If your change genuinely has no user-visible effect
+(test-only changes, internal refactors, CI/infra work), add the
+`skip-changelog` label to the PR instead of writing an entry -- adding or
+removing the label re-runs the check.
+
+## Cutting a release
+
+Releases are ad hoc: whenever a maintainer decides enough has landed in
+`[Unreleased]` to justify one, not on a fixed schedule. There's no
+conventional-commit history to infer a version bump from automatically, so a
+human picks the version number.
+
+1. **Go to Actions -> "Prepare release" -> Run workflow**, and enter the new
+   version (e.g. `1.1.0`, no leading `v`).
+   ([release-prepare.yml](.github/workflows/release-prepare.yml))
+
+   This moves everything currently under `[Unreleased]` into a new
+   `## [1.1.0] - <today>` heading, leaves a fresh empty `[Unreleased]` section
+   above it, and opens a PR (branch `release-v1.1.0`, labeled `release`) with
+   that change. It fails if `[Unreleased]` is empty -- nothing to release.
+
+2. **Review and merge that PR** like any other. This is the only manual
+   review gate in the whole process -- check the CHANGELOG reads well before
+   merging, since everything after this step is automatic.
+
+3. **Merging triggers the rest automatically**
+   ([release-tag.yml](.github/workflows/release-tag.yml)):
+   - Tags the merge commit `v1.1.0`.
+   - Creates a GitHub Release from that version's CHANGELOG section.
+   - Publishes to PyPI, by directly invoking
+     [python-publish.yml](.github/workflows/python-publish.yml) as a reusable
+     workflow (**not** by relying on the `release: published` event it also
+     listens for -- see the note in that file for why that event would never
+     fire here).
+
+No git tag is created by hand, no version string is edited anywhere (the
+package version is derived from the tag via `setuptools-scm`), and there's no
+manual "Draft a new release" click on GitHub.
+
+## One-time repository setup
+
+`release-prepare.yml` pushes a branch and opens a PR using the default
+`GITHUB_TOKEN`. This requires, under **Settings > Actions > General >
+Workflow permissions**:
+
+- "Read and write permissions"
+- "Allow GitHub Actions to create and approve pull requests"
+
+Without these, step 1 above will fail to push the branch or open the PR.
+
+## Bioconda
+
+Bioconda's `bioconda-recipes` repo has its own bot that watches PyPI for new
+stable releases and opens a version-bump PR there automatically -- nothing in
+this repo needs to do anything further once the PyPI publish above succeeds.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=64.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
@@ -11,6 +11,17 @@ where = ["src"]
 [tool.setuptools.package-data]
 "finaletoolkit.frag" = ["data/*.tsv"]
 "finaletoolkit.genome" = ["data/*.gz"]
+
+[tool.setuptools_scm]
+# Derives the package version from git tags/commit distance instead of a
+# hardcoded string. On a tag: "1.0.0". Ahead of a tag: "1.0.1.dev4" (4
+# commits past v1.0.0, guessing the next patch). `local_scheme` is set to
+# drop the "+g<hash>" suffix setuptools_scm normally appends when not
+# exactly on a tag, since PyPI rejects uploads whose version has a local
+# segment -- CI needs a clean version string to publish dev builds.
+version_file = "src/finaletoolkit/_version.py"
+local_scheme = "no-local-version"
+fallback_version = "0.0.0.dev0+unknown"
 
 [project]
 name = "FinaleToolkit"
@@ -48,9 +59,6 @@ dependencies = [
     "rich-click>=1.8",
 ]
 dynamic = ["version"]
-
-[tool.setuptools.dynamic]
-version = {attr = "finaletoolkit.__version__"}
 
 [project.scripts]
 finaletoolkit = "finaletoolkit.cli.main_cli:main_cli"

--- a/scripts/prepare_release.py
+++ b/scripts/prepare_release.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+CHANGELOG.md helpers used by the release-automation workflows.
+
+  bump <version>
+      Move the "## [Unreleased]" section's content under a new
+      "## [<version>] - <date>" heading, leaving a fresh, empty
+      "## [Unreleased]" section above it. Fails if [Unreleased] has no
+      entries -- there's nothing to release.
+
+  extract <version>
+      Print the body of the "## [<version>]" section, for use as a
+      GitHub Release's notes.
+
+Used by ``.github/workflows/release-prepare.yml`` (bump, when preparing a
+release PR) and ``.github/workflows/release-tag.yml`` (extract, when writing
+the GitHub Release body after that PR merges).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import pathlib
+import re
+import sys
+
+CHANGELOG = pathlib.Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+# Matches a Keep a Changelog version heading, e.g. "## [Unreleased]" or
+# "## [1.0.0] - 2026-06-26".
+_HEADING_RE = re.compile(r"^## \[(?P<version>[^\]]+)\](?: - .+)?[ \t]*$", re.MULTILINE)
+
+
+def _sections(text: str) -> list[dict]:
+    """Return each "## [...]" heading's version and content span."""
+    matches = list(_HEADING_RE.finditer(text))
+    sections = []
+    for i, m in enumerate(matches):
+        content_end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        sections.append(
+            {
+                "version": m.group("version"),
+                "heading_start": m.start(),
+                "content_start": m.end(),
+                "content_end": content_end,
+            }
+        )
+    return sections
+
+
+def bump(version: str) -> None:
+    """Move [Unreleased]'s content under a new dated "## [version]" heading."""
+    text = CHANGELOG.read_text()
+    sections = _sections(text)
+    if not sections or sections[0]["version"] != "Unreleased":
+        sys.exit("CHANGELOG.md must start with an '## [Unreleased]' section.")
+
+    unreleased = sections[0]
+    body = text[unreleased["content_start"] : unreleased["content_end"]].strip("\n")
+    if not body:
+        sys.exit(
+            "## [Unreleased] has no entries -- nothing to release. "
+            "Add changelog entries before preparing a release."
+        )
+
+    if any(s["version"] == version for s in sections):
+        sys.exit(f"CHANGELOG.md already has a '## [{version}]' section.")
+
+    today = datetime.date.today().isoformat()
+    replacement = f"## [Unreleased]\n\n## [{version}] - {today}\n\n{body}\n\n"
+    updated = (
+        text[: unreleased["heading_start"]]
+        + replacement
+        + text[unreleased["content_end"] :]
+    )
+    CHANGELOG.write_text(updated)
+    print(f"Prepared CHANGELOG.md for {version} ({today}).")
+
+
+def extract(version: str) -> None:
+    """Print the body of the "## [version]" section."""
+    text = CHANGELOG.read_text()
+    for section in _sections(text):
+        if section["version"] == version:
+            body = text[section["content_start"] : section["content_end"]]
+            print(body.strip("\n"))
+            return
+    sys.exit(f"No '## [{version}]' section found in CHANGELOG.md.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    bump_parser = subparsers.add_parser(
+        "bump", help="Move [Unreleased] content under a new dated version heading."
+    )
+    bump_parser.add_argument(
+        "version", help='Version being released, e.g. "1.1.0" (no leading "v").'
+    )
+
+    extract_parser = subparsers.add_parser(
+        "extract", help="Print a version's changelog section (for release notes)."
+    )
+    extract_parser.add_argument("version")
+
+    args = parser.parse_args()
+    if args.command == "bump":
+        bump(args.version)
+    elif args.command == "extract":
+        extract(args.version)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/finaletoolkit/version.py
+++ b/src/finaletoolkit/version.py
@@ -1,5 +1,14 @@
 """
 Single-source module for the package version number.
+
+The version string is derived from git tags/commit distance by
+setuptools-scm at build/install time, written to the generated
+``finaletoolkit._version`` module. That file doesn't exist in a source
+checkout that hasn't been built or installed yet (e.g. running from a
+raw ``git clone`` without ``pip install``), hence the fallback below.
 """
 
-__version__ = "1.0.0"
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0.dev0+unknown"


### PR DESCRIPTION
## Summary
- Replaces the hand-bumped `__version__ = "1.0.0"` string with `setuptools-scm`: the version is now derived from git tags/commit distance at build/install time -- exactly `"1.0.0"` on a tag, `"1.0.1.dev6"` six commits past one, etc.
- `local_scheme = "no-local-version"` drops the `+g<hash>` suffix setuptools-scm normally appends when not exactly on a tag. This isn't cosmetic: PyPI rejects uploads whose version has a local segment, so this is required groundwork for publishing dev/preview builds later.
- `fallback_version` covers the case where there's no `.git` at all (e.g. a GitHub "Download ZIP" with no tag history).
- CI workflows that build/install the package (`python-package.yml`, `python-publish.yml`, `build-docs.yml`) needed `fetch-depth: 0` added to their checkout step -- the default shallow clone has no tags to derive a version from.

## A bug this surfaced (fixed here, not pre-existing)
Installing `setuptools-scm` activates its own sdist file-finder, which bundles *every git-tracked file* into the sdist by default. That ballooned a test build from ~114KB to **76MB** (`tests/data`'s binary BAM/2bit/CRAM fixtures, `docs/`, `.github/` all got swept in). `MANIFEST.in` now prunes those back out to restore the exact prior scope -- verified the rebuilt sdist matches the old file count precisely (test `.py` files included, test data excluded).

## Verification
- `pip install -e .` -> `finaletoolkit.__version__` / `finaletoolkit --version` both correctly resolve to the git-derived version.
- Resolved to a clean `1.0.0` when checked out exactly at the `v1.0.0` tag (verified via a separate worktree).
- Built sdist + wheel: `METADATA` reports the correct version, wheel contains the generated `_version.py`.
- Full test suite: 130 passed, 11 skipped -- unchanged from baseline.

Dev-workflow note: since the version is frozen into a generated `_version.py` at install time, `finaletoolkit --version` in an editable install won't advance just from pulling new commits -- rerun `pip install -e .` to refresh it. Doesn't affect built/published packages, each CI build starts fresh.

## Update: release-process automation

Added on top of the versioning change, closing the loop on "does releasing still need a manual CHANGELOG PR":

- **`changelog-check.yml`** -- fails a PR that changes `src/finaletoolkit/` without also updating `CHANGELOG.md`. A `skip-changelog` label bypasses it for changes with no user-visible effect.
- **`scripts/prepare_release.py`** -- `bump <version>` moves `[Unreleased]`'s content under a new dated `## [version] - date` heading (fails if `[Unreleased]` is empty); `extract <version>` prints a version's section, used for release notes.
- **`release-prepare.yml`** -- `workflow_dispatch`, manually triggered by a maintainer supplying the version to release. Runs the `bump` script and opens a PR for review. **This is the trigger for the release PR** -- deliberately manual, not scheduled or commit-triggered, since this project releases ad hoc ("whenever we feel enough has been added") rather than on a fixed cadence, and there's no conventional-commit history to auto-infer a version bump from.
- **`release-tag.yml`** -- fires when a `release-vX.Y.Z` PR merges: tags the merge commit, creates a GitHub Release from that version's CHANGELOG section, then directly invokes `python-publish.yml` as a reusable workflow (`workflow_call`). Direct invocation (rather than relying on the `release: published` event `python-publish.yml` also listens for) is necessary because the GitHub Release here is created with the default `GITHUB_TOKEN`, and GitHub does not let `GITHUB_TOKEN`-authored events trigger further workflow runs (anti-recursion) -- so `release: published` would never fire in this path.
- Added a `CHANGELOG.md` entry for this branch's own setuptools-scm change, since `changelog-check.yml` would otherwise flag this PR.

**Full release flow once merged:** maintainer runs `release-prepare.yml` with a version -> reviews/merges the generated PR -> `release-tag.yml` tags, creates the GitHub Release, and publishes to PyPI automatically. No manual tagging, no manual "Draft a new release" click, no version-string file to edit.

**Requires a one-time repo settings change**: Settings > Actions > General > Workflow permissions must allow "Read and write permissions" and "Allow GitHub Actions to create and approve pull requests" -- `release-prepare.yml` pushes a branch and opens a PR with the default token, which needs that permission enabled.

Verified: `prepare_release.py`'s `bump`/`extract` and both error paths (empty `[Unreleased]`, duplicate version) tested against a real copy of `CHANGELOG.md`. All workflow YAML files parse correctly. Full test suite unaffected.

## Test plan
- [x] `pytest tests/ -q` -- 130 passed, 11 skipped
- [x] Version resolves correctly ahead of and exactly on a tag
- [x] `python -m build` produces a correctly-versioned, correctly-scoped sdist and wheel
- [x] `prepare_release.py bump`/`extract` and error paths verified against a real CHANGELOG.md copy
- [x] All new/modified workflow YAML parses correctly
