### PR TITLE
docs: document the Miller-Madow correction added to regional-mds

### DIFF
--- a/docs/documentation/user_guide/features.rst
+++ b/docs/documentation/user_guide/features.rst
@@ -59,9 +59,14 @@ Motif Diversity Score (MDS)
 MDS (*Jiang et al. 2020*) is the normalized Shannon entropy of the end-motif
 k-mer distribution, summarizing end-motif diversity in a single number. The
 regional Motif Diversity Score (rMDS) computes that same entropy per genomic
-region (*Bandaru et al. 2026*).
+region (*Bandaru et al. 2026*). Because the underlying plug-in entropy
+estimator is biased downward in regions with few fragments, ``regional-mds``
+accepts an optional ``--miller-madow`` flag that applies a Miller-Madow bias
+correction, making rMDS values comparable across regions of differing depth.
+It is off by default, so existing output is unchanged unless requested.
 
-:Commands: ``mds`` (whole sample), ``regional-mds`` (per region)
+:Commands: ``mds`` (whole sample), ``regional-mds`` (per region, optionally
+   bias-corrected with ``--miller-madow``)
 
 Cleavage profile
 ----------------

--- a/docs/documentation/workflow/index.rst
+++ b/docs/documentation/workflow/index.rst
@@ -179,7 +179,11 @@ Each command's options below carry the FinaleToolkit flag they map to. Optional
 (``--strand``: ``both``, ``forward``, or ``reverse``), ``*_mapq`` (``-q``),
 ``*_workers`` (``-t``).
 
-**mds** / **regional-mds**: ``*_sep`` (``-s``), ``*_header`` (``--header``).
+**mds**: ``mds_sep`` (``-s``), ``mds_header`` (``--header``).
+
+**regional-mds**: ``regional_mds_sep`` (``-s``), ``regional_mds_header``
+(``--header``), ``regional_mds_miller_madow`` (``--miller-madow``;
+Miller-Madow bias correction, off by default).
 
 **wps**: ``wps_site_bed`` (positional REGIONS), ``wps_reference`` (``-r``),
 ``wps_chrom_sizes`` (``--chrom-sizes``), ``wps_interval_size`` (``-i``),


### PR DESCRIPTION
## Summary

PR #183 added an opt-in `--miller-madow` flag to `regional-mds` (Miller-Madow bias correction for rMDS in low-depth regions), but only updated docstrings and CLI help text -- the hand-written prose docs never got a pass.

- **`docs/documentation/user_guide/features.rst`**: explains what the correction does and that it's off by default, in the existing "Motif Diversity Score (MDS)" section.
- **`docs/documentation/workflow/index.rst`**: the Snakemake workflow config's per-command option reference grouped `**mds** / **regional-mds**` together sharing one `*_sep`/`*_header` option list. `--miller-madow` only exists on `regional-mds`, so that grouping was no longer accurate -- split into two separate entries.

**Not touched, and don't need to be**: the API reference (Sphinx autodoc, pulls from docstrings) and CLI reference (sphinx-click, pulls from `--help`) already reflect the `miller_madow` parameter and `--miller-madow` flag automatically, since PR #183 documented them properly at the source. Verified this by actually building the docs and inspecting the rendered HTML, rather than assuming.

## Verification
- `sphinx-build -b html . _build -W --keep-going` -- zero warnings/errors.
- Extracted rendered HTML text and confirmed the Miller-Madow content appears correctly in `features.html`, `workflow/index.html`, and (already, unedited) `cli_reference/index.html`.
- Full test suite unaffected: 225 passed, 11 skipped.

## Test plan
- [x] Sphinx build clean with warnings-as-errors
- [x] Rendered HTML inspected for all three affected/relevant pages
- [x] `pytest tests/ -q` -- 225 passed, 11 skipped
